### PR TITLE
Fixes #46: propagate encode_row errors in batch write path

### DIFF
--- a/crates/merutable/src/engine/write_path.rs
+++ b/crates/merutable/src/engine/write_path.rs
@@ -145,14 +145,10 @@ pub async fn apply_batch(engine: &Arc<MeruEngine>, batch: MutationBatch) -> Resu
             user_keys.push(user_key_bytes.clone());
         }
         let value_bytes = match mutation.op_type {
-            OpType::Put => mutation
-                .row
-                .as_ref()
-                .map(|r| {
-                    let encoded = codec::encode_row(r).unwrap_or_default();
-                    Bytes::from(encoded)
-                })
-                .unwrap_or_default(),
+            OpType::Put => match mutation.row.as_ref() {
+                Some(r) => Bytes::from(codec::encode_row(r)?),
+                None => Bytes::new(),
+            },
             // Issue #33 fix: capture the delete pre-image at write
             // time instead of reconstructing post-hoc via
             // point_lookup_at(seq-1). The reconstruction approach
@@ -179,7 +175,7 @@ pub async fn apply_batch(engine: &Arc<MeruEngine>, batch: MutationBatch) -> Resu
                 let pre_image =
                     crate::engine::read_path::point_lookup(engine, &mutation.pk_values)?;
                 match pre_image {
-                    Some(row) => Bytes::from(codec::encode_row(&row).unwrap_or_default()),
+                    Some(row) => Bytes::from(codec::encode_row(&row)?),
                     None => Bytes::new(),
                 }
             }
@@ -387,11 +383,30 @@ mod tests {
 
         apply_batch(&engine, batch).await.unwrap();
 
-        // Both keys should be readable.
-        let row1 = engine.get(&[FieldValue::Int64(42)]).unwrap();
-        assert!(row1.is_some());
-        let row2 = engine.get(&[FieldValue::Int64(99)]).unwrap();
-        assert!(row2.is_some());
+        // Issue #46 regression: verify actual field VALUES, not just
+        // existence. The old code used unwrap_or_default() on
+        // encode_row, which would silently produce empty bytes on
+        // failure. decode_row("") returns Row::default() — an empty
+        // row that is_some(). Checking only is_some() would not catch
+        // the data loss.
+        let row1 = engine
+            .get(&[FieldValue::Int64(42)])
+            .unwrap()
+            .expect("key 42 must exist");
+        assert_eq!(
+            row1.get(1).cloned(),
+            Some(FieldValue::Bytes(bytes::Bytes::from("hello"))),
+            "key 42 value must round-trip through batch encode path"
+        );
+        let row2 = engine
+            .get(&[FieldValue::Int64(99)])
+            .unwrap()
+            .expect("key 99 must exist");
+        assert_eq!(
+            row2.get(1).cloned(),
+            Some(FieldValue::Bytes(bytes::Bytes::from("world"))),
+            "key 99 value must round-trip through batch encode path"
+        );
     }
 
     /// Regression: a multi-record `MutationBatch` must advance `global_seq`


### PR DESCRIPTION
## Summary

Two call sites in `apply_batch()` used `codec::encode_row().unwrap_or_default()`, silently collapsing serialization failures into empty bytes. The WAL durably records the empty value, and `decode_row("")` returns `Row::default()` — silent data loss with no error surfaced to the caller.

This is the encode-side twin of Issue #12, which fixed the identical anti-pattern on the decode side.

## Changes

- **`write_path.rs:148–155`** — Put value encoding: replaced `unwrap_or_default()` chain with `match` + `?` error propagation
- **`write_path.rs:182`** — Delete pre-image encoding: replaced `unwrap_or_default()` with `?`
- **Regression test** — Strengthened `apply_batch_writes_and_reads` to verify actual field values (not just `is_some()`). The prior assertion would pass even with empty-bytes data loss since `decode_row("")` produces a non-None Row.

## Test plan

- [x] All 321 unit tests pass
- [x] All integration tests pass (357 total)
- [x] `cargo clippy -p merutable -- -D warnings` clean
- [x] `cargo fmt --check` clean