### PR TITLE
Fixes #45: release merutable 0.0.1 to crates.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+## 0.0.1 — 2026-04-22
+
+Initial public release of the `merutable` crate.
+
+### Highlights
+
+- **Embedded single-table engine** with an LSM-tree architecture. L0
+  SSTables are Parquet tuned as a rowstore (8 KiB pages); L1+ SSTables
+  are Parquet tuned as a columnstore (128 KiB pages). One format, two
+  access patterns.
+- **KV API**: `put`, `get`, `delete`, `scan`, `put_batch` with MVCC
+  sequence numbering. Configurable L0 backpressure via slowdown/stop
+  triggers.
+- **WAL + crash recovery**: CRC-checked write-ahead log with fragmented
+  records. Orphaned WAL files are detected and replayed on reopen.
+- **Compaction**: multi-level, parallel per-level reservation,
+  snapshot-aware tombstone dropping, bounded memory via
+  `max_compaction_input_rows` / `max_compaction_bytes`.
+- **Row cache**: LRU cache for point lookups, invalidated on refresh.
+- **Iceberg v2 metadata**: native protobuf manifest format is a strict
+  superset of Iceberg v2. `export_iceberg(target_dir)` writes
+  `metadata.json` + Avro manifest-list + Avro manifest files. DuckDB
+  `iceberg_scan()`, Spark, Trino, and pyiceberg read the export
+  directly.
+- **Deletion vectors**: Iceberg v3 `deletion-vector-v1` Puffin blobs
+  for point deletes without rewriting data files.
+- **SQL change-feed**: `merutable_changes(table, since_seq)` DataFusion
+  table provider (feature `sql`, enabled by default). Supports INSERT /
+  UPDATE / DELETE discrimination and seq-filter pushdown.
+- **Schema evolution**: additive `add_column` with Iceberg-compatible
+  field IDs, initial defaults, and read-path projection for files
+  written under older schemas.
+- **Mirror worker**: async background upload of flushed files to an
+  object store, with lag alerting and `await_mirror(seq)` for
+  deterministic sync.
+- **Scale-out read-only replica**: `Replica` combines a base `MeruDB`
+  with an in-memory tail fed by `InProcessLogSource`, supporting
+  hot-swap rebase and log-gap recovery.
+- **Metrics facade**: opt-in counters, histograms, and gauges for write
+  path, cache, flush, compaction, and mirror lag. No-op when no recorder
+  is registered.
+- **Graceful shutdown**: `MeruDB::close()` flushes the memtable, fsyncs
+  the WAL, and joins all background workers.
+
+### Bug fixes included in this release
+
+- #46: propagate encode errors in batch write path (was silent data loss)
+- #47: propagate fsync errors and use unique tmp paths in LocalFileStore
+- #48: guard tombstone drop against snapshot-pinned readers (key resurrection)
+- #49: reject NaN in Float/Double primary key encoding (non-deterministic ordering)
+- #54: emit Avro manifest-list and manifest files so `iceberg_scan()` works end-to-end
+- #55: add `await_mirror()` for deterministic sync after flush

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "merutable"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "arc-swap",
  "arrow",

--- a/crates/merutable-python/Cargo.toml
+++ b/crates/merutable-python/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Python bindings for merutable via PyO3"
 license = "Apache-2.0"
+publish = false
 
 [lib]
 name = "merutable"

--- a/crates/merutable/Cargo.toml
+++ b/crates/merutable/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
-name        = "merutable"
-version     = "0.1.0"
-edition     = "2021"
-description = "Embeddable single-table engine: row + columnar Parquet with Iceberg-compatible metadata"
-keywords    = ["embedded", "lsm", "iceberg", "parquet", "table"]
-license     = "Apache-2.0"
-build       = "build.rs"
+name          = "merutable"
+version       = "0.0.1"
+edition       = "2021"
+description   = "Embeddable single-table engine: row + columnar Parquet with Iceberg-compatible metadata"
+keywords      = ["embedded", "lsm", "iceberg", "parquet", "table"]
+license       = "Apache-2.0"
+repository    = "https://github.com/merutable/merutable"
+homepage      = "https://github.com/merutable/merutable"
+documentation = "https://docs.rs/merutable"
+readme        = "../../README.md"
+categories    = ["database-implementations", "data-structures"]
+build         = "build.rs"
 
 # Issue #38: this crate is the single published artifact for
 # merutable. The `sql` and `replica` modules are feature-gated so


### PR DESCRIPTION
## Summary

- Bump `crates/merutable` version from `0.1.0` to `0.0.1` (semver signal: unstable API)
- Add crates.io metadata: `repository`, `homepage`, `documentation`, `readme`, `categories`
- Set `publish = false` on `merutable-python` (excluded from this release)
- Add `CHANGELOG.md` with 0.0.1 release notes covering all features and bug fixes
- `cargo publish --dry-run` passes cleanly

## Test plan

- [x] `cargo publish -p merutable --dry-run` — packages, verifies, and compiles successfully
- [x] All tests pass on main (328 unit + 4 integration + 7 WAL + 3 doc tests)
- [x] `merutable-python` excluded via `publish = false`

## Post-merge

Run `cargo publish -p merutable` to publish to crates.io.