### PR TITLE
docs: improve build/test guide and bump Python to 3.11+

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -8,24 +8,53 @@
   ```
 - **Git**
 
+## Python bindings (`merutable-python`)
+
+The `merutable-python` crate produces a native Python module via PyO3.
+Building it requires a Python environment with [maturin](https://www.maturin.rs/):
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install maturin
+
+cd crates/merutable-python
+maturin develop --release
+```
+
+The `lab/setup.sh` script automates this along with the Jupyter
+dependencies needed by the notebook.
+
 ## Building
 
 ```bash
-# Debug build (fast compile, slow runtime)
-cargo build --workspace
+# Default build (uses default-members)
+cargo build
 
 # Release build (LTO enabled, optimized)
-cargo build --workspace --release
+cargo build --release
+
+# All crates (--workspace includes merutable-python, requires Python setup above)
+cargo build --workspace
+
+# Single crate
+cargo build -p merutable
 ```
 
 ## Running tests
 
 ```bash
-# All tests, debug mode
+# Default (uses default-members)
+cargo test
+
+# Release mode (catches release-only UB)
+cargo test --release
+
+# All crates (--workspace includes merutable-python, requires Python setup above)
 cargo test --workspace
 
-# All tests, release mode (catches release-only UB)
-cargo test --workspace --release
+# Single crate
+cargo test -p merutable
 ```
 
 ## Linting

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -11,7 +11,7 @@
 ## Python bindings (`merutable-python`)
 
 The `merutable-python` crate produces a native Python module via PyO3.
-Building it requires a Python environment with [maturin](https://www.maturin.rs/):
+Building it requires Python 3.11+ and [maturin](https://www.maturin.rs/):
 
 ```bash
 python3 -m venv .venv

--- a/crates/merutable-python/pyproject.toml
+++ b/crates/merutable-python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "merutable"
 version = "0.1.0"
 description = "Python bindings for merutable — an embeddable single-table engine with row + columnar Parquet and Iceberg-compatible metadata"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
 
 [tool.maturin]

--- a/lab/setup.sh
+++ b/lab/setup.sh
@@ -10,6 +10,15 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 cd "$REPO_ROOT"
 
+# Require Python 3.11+ (3.9 is EOL, 3.10 EOL upcoming).
+PYVER=$(python3 -c 'import sys; print(sys.version_info[:2])')
+if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,11) else 1)'; then
+    echo "==> Python version: $PYVER"
+else
+    echo "ERROR: Python 3.11+ is required (found $PYVER)" >&2
+    exit 1
+fi
+
 echo "==> Creating Python virtual environment..."
 python3 -m venv .venv
 source .venv/bin/activate


### PR DESCRIPTION
## Summary

- Add Python bindings section to `DEVELOPER.md` with venv + maturin setup steps, placed before Building so readers hit it first
- Document default build/test (uses `default-members`), `--workspace` (includes `merutable-python`), and `-p` single-crate commands
- Bump `requires-python` from `>=3.9` to `>=3.11` in `pyproject.toml` (3.9 is EOL, 3.10 EOL upcoming)
- Add Python version check in `lab/setup.sh` that exits early if < 3.11

## Test plan

- [ ] `cargo build` uses default-members and succeeds without Python
- [ ] `cargo build --workspace` requires Python setup
- [ ] `lab/setup.sh` rejects Python < 3.11