### PR TITLE
chore: rust-toolchain.toml (stable) + MSRV 1.88.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
+        run: rustup show
 
       - name: Install protoc
         # Issue #28: prost-build needs protoc to compile our internal
@@ -60,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup show
 
       - name: Install protoc
         # Issue #28: prost-build needs protoc; ubuntu-latest does not

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -2,10 +2,12 @@
 
 ## Prerequisites
 
-- **Rust stable** (1.80+): install via [rustup](https://rustup.rs/)
+- **Rust**: install via [rustup](https://rustup.rs/)
   ```
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
   ```
+  The exact toolchain version is pinned in `rust-toolchain.toml` at the workspace root.
+  `rustup` reads this file automatically — no manual version selection needed.
 - **Git**
 
 ## Python bindings (`merutable-python`)

--- a/crates/merutable/Cargo.toml
+++ b/crates/merutable/Cargo.toml
@@ -4,6 +4,7 @@ version       = "0.0.1"
 edition       = "2021"
 description   = "Embeddable single-table engine: row + columnar Parquet with Iceberg-compatible metadata"
 keywords      = ["embedded", "lsm", "iceberg", "parquet", "table"]
+rust-version  = "1.88.0"
 license       = "Apache-2.0"
 repository    = "https://github.com/merutable/merutable"
 homepage      = "https://github.com/merutable/merutable"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "stable"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Supersedes #68 — incorporates munendrasn's rust-toolchain.toml work
with review feedback applied.

## Summary

- Add `rust-toolchain.toml` with `channel = "stable"` and clippy/rustfmt components — single source of truth for local dev and CI
- CI uses `rustup show` which reads the toolchain file
- Add `rust-version = "1.88.0"` to `Cargo.toml` (MSRV floor set by `time 0.3.47`, `darling 0.23.0`, `serde_with 3.18.0`)
- `DEVELOPER.md` references the toolchain file instead of a hardcoded minimum

## Design

- `rust-toolchain.toml` (`stable`) → governs local dev + CI components
- `rust-version` in `Cargo.toml` (`1.88.0`) → protects downstream consumers

## Test plan

- [x] `cargo check` passes
- [ ] CI passes with `rustup show` reading `rust-toolchain.toml`