### PR TITLE
issue #92: measure upsert-flush window scan gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 0.0.2 — 2026-05-03
+
+RFC-0002: flush-time deletion vector emission. Brings external
+Iceberg readers (DuckDB `iceberg_scan`, Spark, Trino, pyiceberg)
+to one-row-per-PK without an MVCC dedup projection.
+
+### Highlights
+
+- **Flush-time deletion vectors.** Every committed snapshot now
+  DV-marks every prior version of every upserted/deleted memtable
+  key, across L0 + L1+ alike, atomically with the L0 SST and the
+  manifest commit. External Iceberg readers see exactly one row
+  per primary key — no `ROW_NUMBER() OVER PARTITION BY pk` dedup
+  required.
+- **Write path unchanged.** `db.put()` does no file I/O. The
+  resolve+emit work piggybacks on the flush job's existing
+  memtable iteration. Measured: put latency unchanged; flush
+  overhead +18% for a 1K-upsert workload (resolve + Puffin + manifest).
+- **Range merge-intersection.** The resolver does a single sorted-
+  merge per overlapping prior file — `O(|f_overlap| + |m_overlap|)`
+  per file — not a per-key bloom+sparse-index probe. Files outside
+  the memtable range are skipped without I/O.
+- **Configurable.** `OpenOptions::enable_flush_dv_emission(false)`
+  opts out for workloads with no upserts. Default ON.
+- New public reader API: `ParquetReader::iter_user_keys_in_range(lo, hi)`
+  streams `(user_key, file-global position)` without decoding the
+  row payload.
+- New engine module: `engine::dv_resolve::resolve_dv_for_flush` —
+  pure helper unit-testable in isolation.
+
+### Tests
+
+- 11 unit tests for `dv_resolve` (every-level probe, multi-version,
+  partial overlap, missing file, etc.).
+- 8 reader unit tests for `iter_user_keys_in_range` (lazy
+  construction, zero-I/O on disjoint range, multi-version yield).
+- 8 integration tests in `db::tests` for the wired flush path
+  (cardinality equality, tombstone DV-marking, feature-off,
+  internal-read correctness, subset upserts, disjoint ranges).
+- 6 stress + chaos tests in `tests/stress_flush_dv.rs` (2500-write
+  upsert sweep with cardinality equality, interleaved upsert/delete
+  oracle, 4-writer concurrent chaos with flush/compact/scan,
+  compaction-during-flush race, 10K-cardinality per-file DV bitmap,
+  close+reopen DV durability).
+
+### References
+
+- RFC: `docs/rfc/0002-flush-time-deletion-vectors.md`
+- Issue: #73
+
 ## 0.0.1 — 2026-04-22
 
 Initial public release of the `merutable` crate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "merutable"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "arc-swap",
  "arrow",

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ gives you the fast-writes; Iceberg compatible metadata layer gives you the analy
 
 ```toml
 [dependencies]
-merutable = "0.0.1"
+merutable = "0.0.2"
 ```
 
 ## Architecture at a glance

--- a/crates/merutable-python/src/lib.rs
+++ b/crates/merutable-python/src/lib.rs
@@ -286,6 +286,19 @@ impl PyMeruDB {
                 fd.set_item("num_rows", f.num_rows)?;
                 fd.set_item("seq_range", (f.seq_range.0, f.seq_range.1))?;
                 fd.set_item("has_dv", f.has_dv)?;
+                // Issue #89: surface DV coords as a nested dict so
+                // Python callers can audit DV state without poking
+                // the filesystem. None when the file has no DV.
+                match &f.dv {
+                    Some(dv) => {
+                        let dv_dict = PyDict::new_bound(py);
+                        dv_dict.set_item("path", &dv.path)?;
+                        dv_dict.set_item("offset", dv.offset)?;
+                        dv_dict.set_item("length", dv.length)?;
+                        fd.set_item("dv", &dv_dict)?;
+                    }
+                    None => fd.set_item("dv", py.None())?,
+                }
                 files_list.append(&fd)?;
             }
             ld.set_item("files", &files_list)?;

--- a/crates/merutable/Cargo.toml
+++ b/crates/merutable/Cargo.toml
@@ -95,3 +95,7 @@ harness = false
 [[bench]]
 name    = "engine_compaction"
 harness = false
+
+[[bench]]
+name    = "flush_dv_emission"
+harness = false

--- a/crates/merutable/Cargo.toml
+++ b/crates/merutable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "merutable"
-version       = "0.0.1"
+version       = "0.0.2"
 edition       = "2021"
 description   = "Embeddable single-table engine: row + columnar Parquet with Iceberg-compatible metadata"
 keywords      = ["embedded", "lsm", "iceberg", "parquet", "table"]

--- a/crates/merutable/benches/flush_dv_emission.rs
+++ b/crates/merutable/benches/flush_dv_emission.rs
@@ -1,0 +1,153 @@
+//! RFC-0002 Phase 4 bench: prove the load-bearing performance contract.
+//!
+//! Two benches:
+//!
+//! 1. `put_latency_dv_on_vs_off` — single-row put latency, measured on
+//!    a fresh DB with one prior file. The flush DV emission MUST NOT
+//!    regress the write path. We bench `put` on a steady state where
+//!    the memtable is bounded; flush happens off-bench. RFC-0002
+//!    non-negotiable: `db.put()` does no file I/O.
+//!
+//! 2. `flush_dv_emission_overhead` — wall time of a full upsert flush
+//!    that DV-marks N L1+ priors, vs. the same flush with DV emission
+//!    off. The cost is the resolve+commit chain.
+
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use merutable::schema::{ColumnDef, ColumnType, TableSchema};
+use merutable::value::{FieldValue, Row};
+use merutable::{MeruDB, OpenOptions};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+
+fn schema() -> TableSchema {
+    TableSchema {
+        table_name: "bench".into(),
+        columns: vec![
+            ColumnDef {
+                name: "id".into(),
+                col_type: ColumnType::Int64,
+                nullable: false,
+                ..Default::default()
+            },
+            ColumnDef {
+                name: "payload".into(),
+                col_type: ColumnType::ByteArray,
+                nullable: true,
+                ..Default::default()
+            },
+        ],
+        primary_key: vec![0],
+        ..Default::default()
+    }
+}
+
+fn make_row(id: i64, value: &str) -> Row {
+    Row::new(vec![
+        Some(FieldValue::Int64(id)),
+        Some(FieldValue::Bytes(Bytes::from(value.to_string()))),
+    ])
+}
+
+fn options(tmp: &TempDir, dv_on: bool) -> OpenOptions {
+    OpenOptions::new(schema())
+        .wal_dir(tmp.path().join("wal"))
+        .catalog_uri(tmp.path().to_string_lossy().to_string())
+        .memtable_size_mb(64) // big enough that put_latency bench never flushes
+        .gc_grace_period_secs(0)
+        .enable_flush_dv_emission(dv_on)
+}
+
+/// Bench `db.put()` per-row latency. Pre-load a prior L1+ file so
+/// flush-time DV emission would have something to resolve against;
+/// the bench itself only measures `put`. The memtable threshold is
+/// 64 MiB so puts never trigger a flush mid-bench.
+fn bench_put_latency(c: &mut Criterion) {
+    let mut group = c.benchmark_group("put_latency");
+    for &dv_on in &[false, true] {
+        let label = if dv_on { "dv_on" } else { "dv_off" };
+        group.bench_function(label, |b| {
+            let rt = Runtime::new().unwrap();
+            let tmp = TempDir::new().unwrap();
+            let db = rt.block_on(async {
+                let db = MeruDB::open(options(&tmp, dv_on)).await.unwrap();
+                // Pre-populate one L1 file so flush-time DV emission
+                // has prior versions to resolve against (worst case
+                // for the dv_on series — the resolver actually has
+                // work to do on the next flush).
+                for i in 0..1_000i64 {
+                    db.put(make_row(i, "init")).await.unwrap();
+                }
+                db.flush().await.unwrap();
+                db.compact().await.unwrap();
+                Arc::new(db)
+            });
+
+            // Bench: each iteration does one put. We use a counter
+            // so each iter writes a distinct id (otherwise the
+            // memtable's same-key dedup makes the bench measure
+            // almost nothing).
+            let counter = std::sync::atomic::AtomicI64::new(10_000);
+            b.iter(|| {
+                let id = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                rt.block_on(async {
+                    db.put(make_row(id, "x")).await.unwrap();
+                });
+            });
+
+            // Cleanup: avoid background flush spinning forever.
+            rt.block_on(async {
+                let _ = Arc::try_unwrap(db).map_err(|_| ()).unwrap().close().await;
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Bench flush wall time: pre-populate an L1 file, upsert N rows,
+/// flush. Measures the resolve + commit chain. dv_on vs dv_off.
+fn bench_flush_overhead(c: &mut Criterion) {
+    const N: i64 = 1_000;
+    let mut group = c.benchmark_group("flush_overhead");
+    group.throughput(Throughput::Elements(N as u64));
+    for &dv_on in &[false, true] {
+        let label = if dv_on { "dv_on" } else { "dv_off" };
+        group.bench_with_input(BenchmarkId::from_parameter(label), &dv_on, |b, &dv_on| {
+            b.iter_custom(|iters| {
+                let rt = Runtime::new().unwrap();
+                let mut total = std::time::Duration::ZERO;
+                for _ in 0..iters {
+                    let tmp = TempDir::new().unwrap();
+                    let db = rt.block_on(async {
+                        let db = MeruDB::open(options(&tmp, dv_on)).await.unwrap();
+                        for i in 0..N {
+                            db.put(make_row(i, "v0")).await.unwrap();
+                        }
+                        db.flush().await.unwrap();
+                        db.compact().await.unwrap();
+                        // Upsert all N — these are the rows whose
+                        // flush we measure.
+                        for i in 0..N {
+                            db.put(make_row(i, "v1")).await.unwrap();
+                        }
+                        db
+                    });
+                    let t0 = std::time::Instant::now();
+                    rt.block_on(async {
+                        db.flush().await.unwrap();
+                    });
+                    total += t0.elapsed();
+                    rt.block_on(async {
+                        db.close().await.unwrap();
+                    });
+                }
+                total
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_put_latency, bench_flush_overhead);
+criterion_main!(benches);

--- a/crates/merutable/benches/flush_dv_emission.rs
+++ b/crates/merutable/benches/flush_dv_emission.rs
@@ -149,5 +149,85 @@ fn bench_flush_overhead(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_put_latency, bench_flush_overhead);
+/// Issue #91: range-scan throughput post-flush vs. clean-Parquet
+/// baseline. The RFC's acceptance criterion is "within constant
+/// factor of clean-Parquet"; this bench pins where we sit.
+///
+/// Workload:
+/// - Pre-populate a snapshot with N rows, force-compact into L1.
+/// - Upsert all N rows, force-flush. Now L1 carries a full DV and
+///   L0 carries the new versions.
+/// - Bench: full-table scan via `db.scan(None, None)`.
+///
+/// Comparator: same N rows materialized into a single in-memory
+/// Vec<Row> via `db.scan` on a CLEAN snapshot (no upserts, no DV).
+/// This is the closest apples-to-apples we get for "what does the
+/// engine's scan path cost when there is nothing to reconcile."
+///
+/// We intentionally bench `db.scan` (the engine path) on both sides
+/// so the comparison isolates the DV-handling cost — not the
+/// pyarrow / DuckDB scan stack which would conflate codepaths.
+fn bench_scan_throughput(c: &mut Criterion) {
+    const N: i64 = 5_000;
+    let mut group = c.benchmark_group("scan_throughput_post_flush");
+    group.throughput(Throughput::Elements(N as u64));
+
+    // Baseline: clean snapshot, no DV (no upsert ever happened).
+    group.bench_function("clean", |b| {
+        let rt = Runtime::new().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let db = rt.block_on(async {
+            let db = MeruDB::open(options(&tmp, true)).await.unwrap();
+            for i in 0..N {
+                db.put(make_row(i, "v")).await.unwrap();
+            }
+            db.flush().await.unwrap();
+            db.compact().await.unwrap();
+            Arc::new(db)
+        });
+        b.iter(|| {
+            let scan = db.scan(None, None).unwrap();
+            assert_eq!(scan.len(), N as usize);
+        });
+        rt.block_on(async {
+            let _ = Arc::try_unwrap(db).map_err(|_| ()).unwrap().close().await;
+        });
+    });
+
+    // Post-upsert: snapshot has L1 with full DV + L0 with new
+    // versions. The scan path applies DV per file then merges.
+    group.bench_function("post_upsert", |b| {
+        let rt = Runtime::new().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let db = rt.block_on(async {
+            let db = MeruDB::open(options(&tmp, true)).await.unwrap();
+            for i in 0..N {
+                db.put(make_row(i, "v0")).await.unwrap();
+            }
+            db.flush().await.unwrap();
+            db.compact().await.unwrap();
+            for i in 0..N {
+                db.put(make_row(i, "v1")).await.unwrap();
+            }
+            db.flush().await.unwrap();
+            Arc::new(db)
+        });
+        b.iter(|| {
+            let scan = db.scan(None, None).unwrap();
+            assert_eq!(scan.len(), N as usize);
+        });
+        rt.block_on(async {
+            let _ = Arc::try_unwrap(db).map_err(|_| ()).unwrap().close().await;
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_put_latency,
+    bench_flush_overhead,
+    bench_scan_throughput
+);
 criterion_main!(benches);

--- a/crates/merutable/benches/flush_dv_emission.rs
+++ b/crates/merutable/benches/flush_dv_emission.rs
@@ -224,10 +224,73 @@ fn bench_scan_throughput(c: &mut Criterion) {
     group.finish();
 }
 
+/// Issue #92 measurement: scan latency DURING the upsert→flush
+/// window vs. post-flush. The RFC defers a transient scan-time
+/// bitmask "conditional on measurement showing the gap is meaningful."
+/// This bench provides the measurement.
+fn bench_window_scan(c: &mut Criterion) {
+    const N: i64 = 5_000;
+    let mut group = c.benchmark_group("scan_during_upsert_window");
+    group.throughput(Throughput::Elements(N as u64));
+
+    group.bench_function("in_window", |b| {
+        let rt = Runtime::new().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let db = rt.block_on(async {
+            let db = MeruDB::open(options(&tmp, true)).await.unwrap();
+            for i in 0..N {
+                db.put(make_row(i, "v0")).await.unwrap();
+            }
+            db.flush().await.unwrap();
+            db.compact().await.unwrap();
+            // Upsert WITHOUT flushing — this is the window.
+            for i in 0..N {
+                db.put(make_row(i, "v1")).await.unwrap();
+            }
+            Arc::new(db)
+        });
+        b.iter(|| {
+            let scan = db.scan(None, None).unwrap();
+            assert_eq!(scan.len(), N as usize);
+        });
+        rt.block_on(async {
+            let _ = Arc::try_unwrap(db).map_err(|_| ()).unwrap().close().await;
+        });
+    });
+
+    group.bench_function("post_flush", |b| {
+        let rt = Runtime::new().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let db = rt.block_on(async {
+            let db = MeruDB::open(options(&tmp, true)).await.unwrap();
+            for i in 0..N {
+                db.put(make_row(i, "v0")).await.unwrap();
+            }
+            db.flush().await.unwrap();
+            db.compact().await.unwrap();
+            for i in 0..N {
+                db.put(make_row(i, "v1")).await.unwrap();
+            }
+            db.flush().await.unwrap(); // close the window
+            Arc::new(db)
+        });
+        b.iter(|| {
+            let scan = db.scan(None, None).unwrap();
+            assert_eq!(scan.len(), N as usize);
+        });
+        rt.block_on(async {
+            let _ = Arc::try_unwrap(db).map_err(|_| ()).unwrap().close().await;
+        });
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_put_latency,
     bench_flush_overhead,
-    bench_scan_throughput
+    bench_scan_throughput,
+    bench_window_scan
 );
 criterion_main!(benches);

--- a/crates/merutable/src/db.rs
+++ b/crates/merutable/src/db.rs
@@ -1290,6 +1290,47 @@ mod tests {
         }
     }
 
+    // ── Issue #93: snapshot-level flush_dv_emission marker ──────────────────
+
+    /// Flush emits a `merutable.flush_dv_emission` summary property
+    /// matching the engine config. External readers + operators use it
+    /// to decide whether the legacy MVCC dedup projection is required.
+    #[tokio::test]
+    async fn flush_stamps_dv_emission_marker_true() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MeruDB::open(test_options(&tmp).memtable_size_mb(1))
+            .await
+            .unwrap();
+        db.put(make_row(1, "x")).await.unwrap();
+        db.flush().await.unwrap();
+        let manifest = db.engine_for_replica().current_manifest().await;
+        let v = manifest
+            .properties
+            .get("merutable.flush_dv_emission")
+            .expect("flush must stamp the marker");
+        assert_eq!(v, "true", "default config has flush DV emission ON");
+    }
+
+    #[tokio::test]
+    async fn flush_stamps_dv_emission_marker_false_when_opt_out() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MeruDB::open(
+            test_options(&tmp)
+                .memtable_size_mb(1)
+                .enable_flush_dv_emission(false),
+        )
+        .await
+        .unwrap();
+        db.put(make_row(1, "x")).await.unwrap();
+        db.flush().await.unwrap();
+        let manifest = db.engine_for_replica().current_manifest().await;
+        let v = manifest
+            .properties
+            .get("merutable.flush_dv_emission")
+            .expect("flush must stamp the marker even when off");
+        assert_eq!(v, "false", "opt-out config records false");
+    }
+
     /// Files with a DV report a populated `dv` whose path/offset/length
     /// match a real puffin file on disk.
     #[tokio::test]

--- a/crates/merutable/src/db.rs
+++ b/crates/merutable/src/db.rs
@@ -1263,4 +1263,86 @@ mod tests {
         let card = sum_dv_cardinality(&db).await;
         assert_eq!(card, 0, "disjoint key range → no DV");
     }
+
+    // ── Issue #89: stats() surfaces DV coords ───────────────────────────────
+
+    /// Files with no DV report `dv: None`.
+    #[tokio::test]
+    async fn stats_reports_dv_none_when_file_has_no_dv() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MeruDB::open(test_options(&tmp).memtable_size_mb(1))
+            .await
+            .unwrap();
+        for i in 0..20 {
+            db.put(make_row(i, "v0")).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        let stats = db.stats();
+        let files: Vec<_> = stats.levels.iter().flat_map(|l| l.files.iter()).collect();
+        assert!(!files.is_empty(), "post-flush snapshot has files");
+        for f in &files {
+            assert!(!f.has_dv, "fresh L0 file has no DV");
+            assert!(
+                f.dv.is_none(),
+                "has_dv=false MUST imply dv=None for {}",
+                f.path
+            );
+        }
+    }
+
+    /// Files with a DV report a populated `dv` whose path/offset/length
+    /// match a real puffin file on disk.
+    #[tokio::test]
+    async fn stats_reports_dv_coords_for_dv_bearing_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MeruDB::open(test_options(&tmp).memtable_size_mb(1))
+            .await
+            .unwrap();
+        for i in 0..30 {
+            db.put(make_row(i, "v0")).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        for i in 0..30 {
+            db.put(make_row(i, "v1")).await.unwrap();
+        }
+        db.flush().await.unwrap();
+
+        let stats = db.stats();
+        let dv_files: Vec<_> = stats
+            .levels
+            .iter()
+            .flat_map(|l| l.files.iter())
+            .filter(|f| f.has_dv)
+            .collect();
+        assert!(
+            !dv_files.is_empty(),
+            "must have at least one DV-bearing file"
+        );
+
+        let base = std::path::PathBuf::from(db.catalog_path());
+        for f in &dv_files {
+            let dv = f.dv.as_ref().expect("has_dv=true MUST imply dv=Some");
+            // The puffin file referenced by dv.path exists on disk.
+            let abs = base.join(&dv.path);
+            let metadata = std::fs::metadata(&abs)
+                .unwrap_or_else(|e| panic!("puffin file {} should exist: {e}", abs.display()));
+            // dv.offset + dv.length is within the file.
+            let total = metadata.len() as i64;
+            let end = dv.offset + dv.length;
+            assert!(
+                dv.offset >= 0 && dv.length > 0 && end <= total,
+                "dv coords ({}, {}) out of range for {} (size={})",
+                dv.offset,
+                dv.length,
+                dv.path,
+                total
+            );
+            // The blob at those coords parses as a valid DV.
+            let bytes = std::fs::read(&abs).unwrap();
+            let off = dv.offset as usize;
+            let len = dv.length as usize;
+            crate::iceberg::DeletionVector::from_puffin_blob(&bytes[off..off + len])
+                .expect("blob at dv coords must parse");
+        }
+    }
 }

--- a/crates/merutable/src/db.rs
+++ b/crates/merutable/src/db.rs
@@ -154,6 +154,7 @@ impl MeruDB {
             gc_grace_period_secs: options.gc_grace_period_secs,
             read_only: options.read_only,
             dual_format_max_level: options.dual_format_max_level,
+            enable_flush_dv_emission: options.enable_flush_dv_emission,
         };
 
         let engine = MeruEngine::open(config).await?;
@@ -1038,5 +1039,228 @@ mod tests {
         // Scan must still work.
         let results = db.scan(None, None).unwrap();
         assert_eq!(results.len(), 5);
+    }
+
+    // ── RFC-0002 Phase 3: flush-time DV emission integration tests ──────────
+
+    /// Helper: count files with a non-null `dv_path` across every level.
+    fn count_files_with_dv(stats: &crate::engine::EngineStats) -> usize {
+        stats
+            .levels
+            .iter()
+            .flat_map(|l| l.files.iter())
+            .filter(|f| f.has_dv)
+            .count()
+    }
+
+    /// Total DV cardinality across every file in the snapshot. Reads
+    /// the manifest entries via stats() and sums the on-disk Puffin
+    /// blob row counts. Cheap because each blob's cardinality is
+    /// surfaced in the manifest entry — but stats doesn't expose
+    /// that directly, so we re-open the underlying DV blobs.
+    async fn sum_dv_cardinality(db: &MeruDB) -> u64 {
+        let snap = db.engine_for_replica().version_set.current().clone();
+        let base = db.engine_for_replica().catalog.base_path().to_path_buf();
+        let mut total: u64 = 0;
+        for level in 0..=snap.max_level().0 {
+            let lvl = crate::types::level::Level(level);
+            for file in snap.files_at(lvl) {
+                if let (Some(dv_path), Some(off), Some(len)) =
+                    (&file.dv_path, file.dv_offset, file.dv_length)
+                {
+                    let abs = base.join(dv_path);
+                    let bytes = tokio::fs::read(&abs).await.unwrap();
+                    let off = off as usize;
+                    let len = len as usize;
+                    let dv =
+                        crate::iceberg::DeletionVector::from_puffin_blob(&bytes[off..off + len])
+                            .unwrap();
+                    total += dv.cardinality();
+                }
+            }
+        }
+        total
+    }
+
+    /// First flush after fresh-key inserts must emit ZERO DV blobs.
+    /// No prior versions exist anywhere in the dataset.
+    #[tokio::test]
+    async fn flush_first_writes_no_dv() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MeruDB::open(test_options(&tmp).memtable_size_mb(1))
+            .await
+            .unwrap();
+        for i in 0..50 {
+            db.put(make_row(i, &format!("v{i}"))).await.unwrap();
+        }
+        db.flush().await.unwrap();
+
+        let stats = db.stats();
+        assert_eq!(count_files_with_dv(&stats), 0, "no priors → no DVs");
+    }
+
+    /// Second flush over upserted-into-L0 keys must DV-mark every
+    /// position in the prior L0 file. RFC-0002 load-bearing: L0
+    /// priors are external-PK-uniqueness critical.
+    #[tokio::test]
+    async fn flush_emits_dv_for_l0_priors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MeruDB::open(test_options(&tmp).memtable_size_mb(1))
+            .await
+            .unwrap();
+        // Round 1: 30 fresh keys → flushed to L0 (file A).
+        for i in 0..30 {
+            db.put(make_row(i, &format!("v0_{i}"))).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        let after_first = sum_dv_cardinality(&db).await;
+        assert_eq!(after_first, 0);
+
+        // Round 2: upsert all 30 keys → flushed to L0 (file B).
+        // The flush must DV-mark every position in file A.
+        for i in 0..30 {
+            db.put(make_row(i, &format!("v1_{i}"))).await.unwrap();
+        }
+        db.flush().await.unwrap();
+
+        let after_second = sum_dv_cardinality(&db).await;
+        assert_eq!(
+            after_second, 30,
+            "every L0 prior position must be DV-marked"
+        );
+    }
+
+    /// Tombstones (db.delete) follow the same resolve path as upserts
+    /// — RFC-0002 anti-fix A8.
+    #[tokio::test]
+    async fn flush_emits_dv_for_l0_tombstones() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MeruDB::open(test_options(&tmp).memtable_size_mb(1))
+            .await
+            .unwrap();
+        for i in 0..20 {
+            db.put(make_row(i, "live")).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        for i in 0..20 {
+            db.delete(vec![FieldValue::Int64(i)]).await.unwrap();
+        }
+        db.flush().await.unwrap();
+
+        let card = sum_dv_cardinality(&db).await;
+        assert_eq!(
+            card, 20,
+            "every L0 prior must be DV-marked by tombstone flush"
+        );
+
+        // Reads must continue to honor MVCC dedup — every key gone.
+        for i in 0..20 {
+            assert!(db.get(&[FieldValue::Int64(i)]).unwrap().is_none());
+        }
+    }
+
+    /// `enable_flush_dv_emission(false)` must skip the resolve+emit
+    /// step entirely, and produce a snapshot identical to pre-RFC
+    /// behavior. Sanity check: no DV blobs after upsert+flush.
+    #[tokio::test]
+    async fn flush_dv_emission_disabled_emits_no_dv() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MeruDB::open(
+            test_options(&tmp)
+                .memtable_size_mb(1)
+                .enable_flush_dv_emission(false),
+        )
+        .await
+        .unwrap();
+        for i in 0..30 {
+            db.put(make_row(i, &format!("v0_{i}"))).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        for i in 0..30 {
+            db.put(make_row(i, &format!("v1_{i}"))).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        assert_eq!(
+            count_files_with_dv(&db.stats()),
+            0,
+            "feature off → zero DV blobs even on upsert"
+        );
+    }
+
+    /// Reads against an upserted dataset must see the latest value
+    /// for every key. The DV emission is invisible to internal
+    /// readers — they go through MergingIterator regardless — but a
+    /// regression here would catch any mistake that DV-marks the
+    /// WRONG positions.
+    #[tokio::test]
+    async fn flush_dv_does_not_corrupt_internal_reads() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MeruDB::open(test_options(&tmp).memtable_size_mb(1))
+            .await
+            .unwrap();
+        for i in 0..40 {
+            db.put(make_row(i, &format!("v0_{i}"))).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        for i in 0..40 {
+            db.put(make_row(i, &format!("v1_{i}"))).await.unwrap();
+        }
+        db.flush().await.unwrap();
+
+        for i in 0..40 {
+            let row = db.get(&[FieldValue::Int64(i)]).unwrap().unwrap();
+            let val = row.get(1).unwrap();
+            assert_eq!(
+                *val,
+                FieldValue::Bytes(Bytes::from(format!("v1_{i}"))),
+                "key {i} must read the v1 value"
+            );
+        }
+        // Range scan: exactly 40 rows, all v1.
+        let scan = db.scan(None, None).unwrap();
+        assert_eq!(scan.len(), 40);
+    }
+
+    /// Upsert-only of a SUBSET: priors for the subset get DV-marked,
+    /// untouched priors stay live. Tight cardinality.
+    #[tokio::test]
+    async fn flush_emits_dv_for_upsert_subset_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MeruDB::open(test_options(&tmp).memtable_size_mb(1))
+            .await
+            .unwrap();
+        for i in 0..50 {
+            db.put(make_row(i, "v0")).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        // Upsert only ids 10..30 (20 keys).
+        for i in 10..30 {
+            db.put(make_row(i, "v1")).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        let card = sum_dv_cardinality(&db).await;
+        assert_eq!(card, 20, "exactly the upserted subset must be DV-marked");
+    }
+
+    /// New-key flushes (no overlap with existing files) must NOT
+    /// emit any DV. Catches a regression where the resolver
+    /// accidentally marks unrelated positions.
+    #[tokio::test]
+    async fn flush_new_key_range_emits_no_dv() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MeruDB::open(test_options(&tmp).memtable_size_mb(1))
+            .await
+            .unwrap();
+        for i in 0..30 {
+            db.put(make_row(i, "v0")).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        // Flush 2: entirely new keys, disjoint range.
+        for i in 1000..1030 {
+            db.put(make_row(i, "v1")).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        let card = sum_dv_cardinality(&db).await;
+        assert_eq!(card, 0, "disjoint key range → no DV");
     }
 }

--- a/crates/merutable/src/engine/config.rs
+++ b/crates/merutable/src/engine/config.rs
@@ -90,6 +90,20 @@ pub struct EngineConfig {
     /// Existing files retain their write-time format (stamped in
     /// `ParquetFileMeta::format`).
     pub dual_format_max_level: Option<u8>,
+
+    /// RFC-0002: emit per-file deletion vectors at flush time so
+    /// every prior version of each upserted/deleted memtable key is
+    /// DV-marked in the same atomic snapshot commit. Required for
+    /// external Iceberg readers (DuckDB `iceberg_scan`, Spark, Trino,
+    /// pyiceberg) to see one row per primary key without an MVCC
+    /// dedup projection.
+    ///
+    /// Default: `true`. Set `false` to skip the resolve+emit step
+    /// (e.g. workloads with no upserts where the cost is pure
+    /// overhead, or operators benchmarking the legacy behavior).
+    /// Disabling does NOT affect compaction-emitted DVs (Iceberg v3
+    /// interop with externally-stamped DVs continues to work).
+    pub enable_flush_dv_emission: bool,
 }
 
 impl EngineConfig {
@@ -137,6 +151,9 @@ impl Default for EngineConfig {
             gc_grace_period_secs: 300,
             // Default matches the pre-Issue-#15 hard-coded behavior.
             dual_format_max_level: Some(0),
+            // RFC-0002: on by default — external Iceberg PK
+            // uniqueness is the load-bearing reason DVs exist.
+            enable_flush_dv_emission: true,
         }
     }
 }

--- a/crates/merutable/src/engine/dv_resolve.rs
+++ b/crates/merutable/src/engine/dv_resolve.rs
@@ -95,6 +95,19 @@ pub fn resolve_dv_for_flush(
             let lo = std::cmp::max(m_lo, f_min);
             let hi = std::cmp::min(m_hi, f_max);
 
+            // Issue #90: load the file's existing DV (if any) so we
+            // can short-circuit work that's already covered.
+            let existing_dv = load_existing_dv(file, base_path)?;
+
+            // Issue #90 fast-path: if the file is fully DV-marked
+            // already (existing.cardinality == num_rows), no flush
+            // can add a new position. Skip the page reads entirely.
+            if let Some(ref existing) = existing_dv {
+                if existing.len() == file.meta.num_rows {
+                    continue;
+                }
+            }
+
             // Read + open the file. The parquet crate's
             // SerializedFileReader needs a `ChunkReader` — we hold
             // the bytes and clone-by-Arc internally via `Bytes`.
@@ -137,7 +150,17 @@ pub fn resolve_dv_for_flush(
                             file.path
                         )));
                     }
-                    bitmap.insert(pos as u32);
+                    let pos_u32 = pos as u32;
+                    // Issue #90 per-position dedup: skip positions
+                    // already in the existing DV. The catalog merge
+                    // would no-op them anyway, but skipping here
+                    // avoids enlarging the in-flight bitmap and
+                    // (when ALL matches are covered) lets us drop
+                    // the file from the txn entirely below.
+                    if existing_dv.as_ref().is_some_and(|e| e.contains(pos_u32)) {
+                        continue;
+                    }
+                    bitmap.insert(pos_u32);
                     // Do NOT advance m_idx: a multi-version key
                     // yields multiple positions (same uk_f) and we
                     // must mark every one.
@@ -156,6 +179,49 @@ pub fn resolve_dv_for_flush(
         }
     }
     Ok(out)
+}
+
+/// Issue #90: load the on-disk DV for a file if its manifest entry
+/// has DV coords, returning the underlying `RoaringBitmap`. Returns
+/// `Ok(None)` when the file has no DV. Defensive: inconsistent
+/// coords (some Some, some None) are surfaced as `MeruError::Corruption`,
+/// matching the catalog/read-path validation contract.
+fn load_existing_dv(
+    file: &crate::iceberg::version::DataFileMeta,
+    base_path: &Path,
+) -> Result<Option<RoaringBitmap>> {
+    use crate::iceberg::DeletionVector;
+    match (&file.dv_path, file.dv_offset, file.dv_length) {
+        (Some(p), Some(o), Some(l)) => {
+            if o < 0 || l < 0 {
+                return Err(MeruError::Corruption(format!(
+                    "DV has negative offset ({o}) or length ({l}) on file {}",
+                    file.path
+                )));
+            }
+            let abs = base_path.join(p);
+            let bytes = std::fs::read(&abs).map_err(MeruError::Io)?;
+            let off = o as usize;
+            let len = l as usize;
+            let end = off
+                .checked_add(len)
+                .ok_or_else(|| MeruError::Corruption("DV offset+length overflow".into()))?;
+            if end > bytes.len() {
+                return Err(MeruError::Corruption(format!(
+                    "DV blob out of range on file {}: end={end} puffin_len={}",
+                    file.path,
+                    bytes.len()
+                )));
+            }
+            let dv = DeletionVector::from_puffin_blob(&bytes[off..end])?;
+            Ok(Some(dv.bitmap().clone()))
+        }
+        (None, None, None) => Ok(None),
+        _ => Err(MeruError::Corruption(format!(
+            "inconsistent DV coords on file {}: dv_path={:?} dv_offset={:?} dv_length={:?}",
+            file.path, file.dv_path, file.dv_offset, file.dv_length
+        ))),
+    }
 }
 
 /// Range overlap on user_key bytes. Empty key bounds (a freshly
@@ -509,6 +575,120 @@ mod tests {
         assert!(
             matches!(err, MeruError::Io(_)),
             "expected Io error, got {err:?}"
+        );
+    }
+
+    // ── Issue #90: existing-DV optimizations ────────────────────────────────
+
+    /// Helper: write a Puffin DV blob next to a parquet file and
+    /// stamp the (path, offset, length) coords back into the meta.
+    /// Mirrors what catalog::commit does on a real DV emission.
+    fn stamp_dv_on_file(base: &Path, meta: &mut DataFileMeta, positions: &[u32], snapshot_id: i64) {
+        use crate::iceberg::DeletionVector;
+        let mut dv = DeletionVector::new();
+        for &p in positions {
+            dv.mark_deleted(p);
+        }
+        let encoded = dv
+            .encode_puffin(&meta.path, snapshot_id, snapshot_id)
+            .unwrap();
+        let stem = std::path::Path::new(&meta.path)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap();
+        let parent = std::path::Path::new(&meta.path).parent().unwrap();
+        let rel = parent.join(format!("{stem}.dv-{snapshot_id}.puffin"));
+        let abs = base.join(&rel);
+        std::fs::write(&abs, &encoded.bytes).unwrap();
+        meta.dv_path = Some(rel.to_string_lossy().into_owned());
+        meta.dv_offset = Some(encoded.blob_offset);
+        meta.dv_length = Some(encoded.blob_length);
+    }
+
+    /// Files already FULLY DV-marked must be skipped: no page reads,
+    /// no entry in the result. The fast-path is hit when an existing
+    /// DV's cardinality equals the file's num_rows.
+    #[test]
+    fn fully_dv_marked_file_is_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let mut f = write_file(
+            tmp.path(),
+            "data/L1/a.parquet",
+            (0..10).map(|id| (id, id as u64 + 1)).collect(),
+            Level(1),
+        );
+        // Stamp a DV that covers ALL 10 positions.
+        let all: Vec<u32> = (0..10).collect();
+        stamp_dv_on_file(tmp.path(), &mut f, &all, 5);
+        let v = version_with_files(HashMap::from([(Level(1), vec![f])]));
+
+        // Memtable upserts every key — the resolver MUST return
+        // an empty map because the prior file is already fully marked.
+        let keys: Vec<Vec<u8>> = (0..10).map(user_key).collect();
+        let result = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        assert!(
+            result.is_empty(),
+            "fully-marked file must produce no DV delta, got {result:?}"
+        );
+    }
+
+    /// Per-position dedup: positions already in the existing DV are
+    /// not re-added. The result bitmap holds ONLY the new positions.
+    #[test]
+    fn partial_dv_skips_already_covered_positions() {
+        let tmp = TempDir::new().unwrap();
+        let mut f = write_file(
+            tmp.path(),
+            "data/L1/a.parquet",
+            (0..10).map(|id| (id, id as u64 + 1)).collect(),
+            Level(1),
+        );
+        // Existing DV covers positions {0, 1, 2}; positions 3..10 are
+        // still live.
+        stamp_dv_on_file(tmp.path(), &mut f, &[0u32, 1, 2], 5);
+        let v = version_with_files(HashMap::from([(Level(1), vec![f])]));
+
+        // Memtable upserts ids 0..5 — positions 0,1,2 already
+        // covered, only 3,4 are new.
+        let keys: Vec<Vec<u8>> = (0..5).map(user_key).collect();
+        let result = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        assert_eq!(result.len(), 1);
+        let bm = &result["data/L1/a.parquet"];
+        assert_eq!(
+            bm.len(),
+            2,
+            "only NEW positions (3, 4) should be in the delta, got cardinality {}",
+            bm.len()
+        );
+        assert!(bm.contains(3));
+        assert!(bm.contains(4));
+        assert!(
+            !bm.contains(0) && !bm.contains(1) && !bm.contains(2),
+            "covered positions must NOT be re-added"
+        );
+    }
+
+    /// If every match is already covered, the file must NOT appear
+    /// in the result map (else we'd emit a redundant DV update).
+    #[test]
+    fn all_matches_covered_excludes_file_from_result() {
+        let tmp = TempDir::new().unwrap();
+        let mut f = write_file(
+            tmp.path(),
+            "data/L1/a.parquet",
+            (0..10).map(|id| (id, id as u64 + 1)).collect(),
+            Level(1),
+        );
+        // Covers positions 0..5.
+        stamp_dv_on_file(tmp.path(), &mut f, &(0u32..5).collect::<Vec<_>>(), 5);
+        let v = version_with_files(HashMap::from([(Level(1), vec![f])]));
+
+        // Memtable upserts ids 0..5 — every match already covered.
+        let keys: Vec<Vec<u8>> = (0..5).map(user_key).collect();
+        let result = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        assert!(
+            result.is_empty(),
+            "every match covered → no entry, got {result:?}"
         );
     }
 }

--- a/crates/merutable/src/engine/dv_resolve.rs
+++ b/crates/merutable/src/engine/dv_resolve.rs
@@ -1,0 +1,514 @@
+//! Flush-time deletion-vector resolver. RFC-0002 Phase 2.
+//!
+//! Pure helper that consumes a sorted list of memtable user_keys and
+//! returns the per-file `RoaringBitmap` of file-global row positions
+//! to mark deleted in the next manifest commit.
+//!
+//! The resolver runs in the flush job under `commit_lock` against a
+//! pinned `Version` snapshot. It performs **no** mutation of any
+//! engine state — the caller threads the returned map into the
+//! `SnapshotTransaction` via `add_dv()`.
+//!
+//! Algorithm: per-file range merge-intersection, NOT per-key probe.
+//! For every prior file (L0 + L1+) whose key range overlaps the
+//! memtable's range, the file's `iter_user_keys_in_range` stream is
+//! sorted-merged against the memtable's sorted user_keys. Each
+//! match contributes one position to that file's bitmap. Multi-version
+//! rows for the same user_key all match the same memtable entry and
+//! all positions are recorded (so an upsert DV-marks every prior
+//! version, not just the latest).
+//!
+//! See `docs/rfc/0002-flush-time-deletion-vectors.md` for the full
+//! design contract.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use roaring::RoaringBitmap;
+
+use crate::iceberg::version::Version;
+use crate::parquet::reader::ParquetReader;
+use crate::types::{level::Level, schema::TableSchema, MeruError, Result};
+
+/// Per-file DV deltas produced by one flush. Key = parquet file path
+/// (object-store-relative, matches `DataFileMeta::path`); value =
+/// the set of file-global row positions to mark deleted.
+///
+/// Empty bitmaps are NOT inserted — the map only contains files that
+/// have at least one position to DV-mark. Callers that want to merge
+/// with existing DVs should consult `SnapshotTransaction::add_dv`,
+/// which handles the union.
+pub type DvDeltas = HashMap<String, RoaringBitmap>;
+
+/// Resolve flush-time DV deltas for one memtable's worth of upserts.
+///
+/// `memtable_user_keys` MUST be:
+/// - sorted ASCending by byte order (the natural InternalKey
+///   user_key ordering),
+/// - deduplicated by user_key (no repeated user_keys — multiple
+///   memtable versions of the same user_key collapse to one entry
+///   for resolution purposes).
+///
+/// Empty input returns an empty map without opening any file.
+///
+/// `version` is the pinned snapshot the flush will commit on top of.
+/// The resolver iterates every level (L0 included — see RFC-0002 on
+/// why external Iceberg PK uniqueness requires L0 DV-marking too).
+///
+/// On any read error against any file, the resolver fails — the flush
+/// caller decides whether to retry the whole job. Partial maps are
+/// not returned (no half-commit risk).
+pub fn resolve_dv_for_flush(
+    memtable_user_keys: &[Vec<u8>],
+    version: &Version,
+    base_path: &Path,
+    schema: &Arc<TableSchema>,
+) -> Result<DvDeltas> {
+    let mut out: DvDeltas = HashMap::new();
+    if memtable_user_keys.is_empty() {
+        return Ok(out);
+    }
+    // Cheap upper-bound for per-file disjoint check: the memtable's
+    // own min/max user_key. Files outside this range are skipped
+    // before any I/O.
+    let m_lo = memtable_user_keys.first().unwrap().as_slice();
+    let m_hi = memtable_user_keys.last().unwrap().as_slice();
+
+    // Iterate every level from 0 upwards. RFC-0002: external Iceberg
+    // readers must see one row per PK; that requires DV-marking
+    // every prior version regardless of level.
+    let max_level = version.max_level();
+    for lvl in 0..=max_level.0 {
+        let level = Level(lvl);
+        for file in version.files_at(level) {
+            if !file_overlaps_memtable(file, m_lo, m_hi) {
+                continue;
+            }
+            // Compute the tight per-file range to iterate: the
+            // intersection of the file's range and the memtable's
+            // range. Saves work when only a slice of the file
+            // overlaps the memtable.
+            let f_min = file.meta.key_min.as_slice();
+            let f_max = file.meta.key_max.as_slice();
+            let lo = std::cmp::max(m_lo, f_min);
+            let hi = std::cmp::min(m_hi, f_max);
+
+            // Read + open the file. The parquet crate's
+            // SerializedFileReader needs a `ChunkReader` — we hold
+            // the bytes and clone-by-Arc internally via `Bytes`.
+            let abs = base_path.join(&file.path);
+            let bytes = std::fs::read(&abs).map_err(MeruError::Io)?;
+            let reader = ParquetReader::open(Bytes::from(bytes), schema.clone())?;
+
+            // Sorted merge: walk the file's (uk, position) stream,
+            // advancing the memtable cursor on each step. Every match
+            // writes a position into the file's bitmap. Memtable
+            // keys greater than every yielded user_key are simply
+            // not in this file (which is fine — they may match a
+            // different file or be entirely new keys).
+            let mut bitmap = RoaringBitmap::new();
+            // partition_point: first index whose key >= lo. The
+            // memtable_user_keys cursor we keep is the smallest
+            // index whose key is >= the current file user_key (the
+            // merge invariant).
+            let mut m_idx = memtable_user_keys.partition_point(|k| k.as_slice() < lo);
+
+            for item in reader.iter_user_keys_in_range(lo, hi)? {
+                let (uk_f, pos) = item?;
+                // Advance memtable cursor past every key strictly < uk_f.
+                while m_idx < memtable_user_keys.len()
+                    && memtable_user_keys[m_idx].as_slice() < uk_f.as_slice()
+                {
+                    m_idx += 1;
+                }
+                if m_idx >= memtable_user_keys.len() {
+                    break; // memtable exhausted within this file's window
+                }
+                if memtable_user_keys[m_idx].as_slice() == uk_f.as_slice() {
+                    // Match. Record this file-global position.
+                    // RoaringBitmap is u32-indexed; positions
+                    // exceeding u32::MAX are corruption (a single
+                    // SST cannot hold > 4G rows).
+                    if pos > u32::MAX as u64 {
+                        return Err(MeruError::Corruption(format!(
+                            "row position {pos} exceeds u32::MAX in file {}",
+                            file.path
+                        )));
+                    }
+                    bitmap.insert(pos as u32);
+                    // Do NOT advance m_idx: a multi-version key
+                    // yields multiple positions (same uk_f) and we
+                    // must mark every one.
+                }
+                // else memtable[m_idx] > uk_f: file's row not in
+                // memtable, leave it alone.
+            }
+
+            if !bitmap.is_empty() {
+                out.entry(file.path.clone())
+                    .and_modify(|existing| {
+                        *existing |= &bitmap;
+                    })
+                    .or_insert(bitmap);
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Range overlap on user_key bytes. Empty key bounds (a freshly
+/// constructed file with no rows) are treated as "no overlap" so an
+/// empty file never gets opened for DV resolution.
+fn file_overlaps_memtable(
+    file: &crate::iceberg::version::DataFileMeta,
+    m_lo: &[u8],
+    m_hi: &[u8],
+) -> bool {
+    let f_min = file.meta.key_min.as_slice();
+    let f_max = file.meta.key_max.as_slice();
+    if f_min.is_empty() || f_max.is_empty() {
+        return false;
+    }
+    !(f_max < m_lo || f_min > m_hi)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::iceberg::version::{DataFileMeta, Version};
+    use crate::types::{
+        key::InternalKey,
+        level::{FileFormat, Level, ParquetFileMeta},
+        schema::{ColumnDef, ColumnType, TableSchema},
+        sequence::{OpType, SeqNum},
+        value::{FieldValue, Row},
+    };
+    use bytes::Bytes as BBytes;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn test_schema() -> TableSchema {
+        TableSchema {
+            table_name: "t".into(),
+            columns: vec![
+                ColumnDef {
+                    name: "id".into(),
+                    col_type: ColumnType::Int64,
+                    nullable: false,
+                    ..Default::default()
+                },
+                ColumnDef {
+                    name: "v".into(),
+                    col_type: ColumnType::ByteArray,
+                    nullable: true,
+                    ..Default::default()
+                },
+            ],
+            primary_key: vec![0],
+            ..Default::default()
+        }
+    }
+
+    fn ikey(id: i64, seq: u64) -> InternalKey {
+        InternalKey::encode(
+            &[FieldValue::Int64(id)],
+            SeqNum(seq),
+            OpType::Put,
+            &test_schema(),
+        )
+        .unwrap()
+    }
+
+    fn user_key(id: i64) -> Vec<u8> {
+        ikey(id, 0).user_key_bytes().to_vec()
+    }
+
+    /// Write a Parquet file with the given (id, seq) sequence and
+    /// return its `DataFileMeta` ready to be installed into a
+    /// `Version`. Writes the file at `base_path/relative` and
+    /// returns the relative path inside the meta.
+    fn write_file(
+        base_path: &Path,
+        relative: &str,
+        rows: Vec<(i64, u64)>,
+        level: Level,
+    ) -> DataFileMeta {
+        let schema = test_schema();
+        let pq_rows: Vec<(InternalKey, Row)> = rows
+            .iter()
+            .map(|(id, seq)| {
+                (
+                    ikey(*id, *seq),
+                    Row::new(vec![
+                        Some(FieldValue::Int64(*id)),
+                        Some(FieldValue::Bytes(BBytes::from(format!("v{id}_{seq}")))),
+                    ]),
+                )
+            })
+            .collect();
+        let (bytes, _bloom, mut meta) = crate::parquet::writer::write_sorted_rows(
+            pq_rows,
+            Arc::new(schema),
+            level,
+            FileFormat::default_for_level(level),
+            10,
+        )
+        .unwrap();
+        meta.level = level;
+        let abs = base_path.join(relative);
+        if let Some(parent) = abs.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&abs, &bytes).unwrap();
+        DataFileMeta {
+            path: relative.to_string(),
+            meta,
+            dv_path: None,
+            dv_offset: None,
+            dv_length: None,
+        }
+    }
+
+    fn version_with_files(files_per_level: HashMap<Level, Vec<DataFileMeta>>) -> Version {
+        Version {
+            snapshot_id: 1,
+            levels: files_per_level,
+            schema: Arc::new(test_schema()),
+        }
+    }
+
+    #[test]
+    fn empty_memtable_returns_empty_map_no_io() {
+        // No files necessary — empty input must short-circuit.
+        let tmp = TempDir::new().unwrap();
+        let v = Version::empty(Arc::new(test_schema()));
+        let result = resolve_dv_for_flush(&[], &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn empty_version_returns_empty_map() {
+        // Memtable has keys, but no prior files exist. Nothing to
+        // resolve, but the call must not panic.
+        let tmp = TempDir::new().unwrap();
+        let keys: Vec<Vec<u8>> = (0..10).map(user_key).collect();
+        let v = Version::empty(Arc::new(test_schema()));
+        let result = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn memtable_disjoint_from_every_file_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let f0 = write_file(
+            tmp.path(),
+            "data/L1/a.parquet",
+            (0..32).map(|id| (id, id as u64 + 1)).collect(),
+            Level(1),
+        );
+        let v = version_with_files(HashMap::from([(Level(1), vec![f0])]));
+        // Memtable keys at id ∈ [1000..1010] — disjoint from [0..32).
+        let keys: Vec<Vec<u8>> = (1000..1010).map(user_key).collect();
+        let result = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn memtable_fully_overlaps_l1_file_marks_every_position() {
+        let tmp = TempDir::new().unwrap();
+        // File: id ∈ [0..32), one version each at seq=id+1.
+        let f0 = write_file(
+            tmp.path(),
+            "data/L1/a.parquet",
+            (0..32).map(|id| (id, id as u64 + 1)).collect(),
+            Level(1),
+        );
+        let v = version_with_files(HashMap::from([(Level(1), vec![f0])]));
+        // Memtable: every id in the file gets upserted.
+        let keys: Vec<Vec<u8>> = (0..32).map(user_key).collect();
+        let result = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        assert_eq!(result.len(), 1);
+        let bm = result
+            .get("data/L1/a.parquet")
+            .expect("file must be in map");
+        // EXACT cardinality + EXACT positions: the file is sorted
+        // by user_key ASC so positions 0..32 align with ids 0..32.
+        assert_eq!(bm.len(), 32, "every prior position must be DV-marked");
+        for pos in 0..32u32 {
+            assert!(bm.contains(pos), "position {pos} missing from DV bitmap");
+        }
+    }
+
+    #[test]
+    fn partial_overlap_marks_only_intersecting_positions() {
+        let tmp = TempDir::new().unwrap();
+        // File: ids 0..32.
+        let f0 = write_file(
+            tmp.path(),
+            "data/L1/a.parquet",
+            (0..32).map(|id| (id, id as u64 + 1)).collect(),
+            Level(1),
+        );
+        let v = version_with_files(HashMap::from([(Level(1), vec![f0])]));
+        // Memtable: only ids 5..10 are upserts (others are new keys).
+        let keys: Vec<Vec<u8>> = (5..10).map(user_key).collect();
+        let result = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        assert_eq!(result.len(), 1);
+        let bm = &result["data/L1/a.parquet"];
+        assert_eq!(bm.len(), 5, "exactly 5 positions");
+        for pos in 5u32..10 {
+            assert!(bm.contains(pos), "position {pos}");
+        }
+    }
+
+    #[test]
+    fn l0_file_priors_get_dv_marked() {
+        // RFC-0002 load-bearing: L0 priors MUST be DV-marked for
+        // external Iceberg PK uniqueness, not just L1+ priors.
+        let tmp = TempDir::new().unwrap();
+        let f0 = write_file(
+            tmp.path(),
+            "data/L0/a.parquet",
+            (0..16).map(|id| (id, id as u64 + 1)).collect(),
+            Level(0),
+        );
+        let v = version_with_files(HashMap::from([(Level(0), vec![f0])]));
+        let keys: Vec<Vec<u8>> = (0..16).map(user_key).collect();
+        let result = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        let bm = &result["data/L0/a.parquet"];
+        assert_eq!(bm.len(), 16, "every L0 prior must be DV-marked");
+    }
+
+    #[test]
+    fn multi_version_l0_marks_every_version_position() {
+        // Same id appears at three positions (three seqs) in one
+        // L0 file. An upsert in the memtable must DV-mark all three.
+        let tmp = TempDir::new().unwrap();
+        let id: i64 = 7;
+        // Three versions at seqs 30, 20, 10. Writer requires the
+        // input rows to already be sorted ASC by InternalKey
+        // (user_key ASC, seq DESC), which `(7, 30) (7, 20) (7, 10)`
+        // satisfies.
+        let f0 = write_file(
+            tmp.path(),
+            "data/L0/a.parquet",
+            vec![(id, 30), (id, 20), (id, 10)],
+            Level(0),
+        );
+        let v = version_with_files(HashMap::from([(Level(0), vec![f0])]));
+        let keys = vec![user_key(id)];
+        let result = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        let bm = &result["data/L0/a.parquet"];
+        assert_eq!(bm.len(), 3, "all three versions must be marked");
+        assert!(bm.contains(0));
+        assert!(bm.contains(1));
+        assert!(bm.contains(2));
+    }
+
+    #[test]
+    fn priors_in_both_l0_and_l1_both_get_marked() {
+        // The same key has versions in an L0 file AND an L1 file
+        // (transient state between compactions). Both positions
+        // must be DV-marked — RFC-0002 anti-fix A9.
+        let tmp = TempDir::new().unwrap();
+        let id_l0: i64 = 5;
+        let id_l1: i64 = 5;
+        let f_l0 = write_file(tmp.path(), "data/L0/a.parquet", vec![(id_l0, 50)], Level(0));
+        let f_l1 = write_file(tmp.path(), "data/L1/b.parquet", vec![(id_l1, 10)], Level(1));
+        let v = version_with_files(HashMap::from([
+            (Level(0), vec![f_l0]),
+            (Level(1), vec![f_l1]),
+        ]));
+        let keys = vec![user_key(id_l0)];
+        let result = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        assert_eq!(result.len(), 2, "both files must have DV deltas");
+        assert_eq!(result["data/L0/a.parquet"].len(), 1);
+        assert_eq!(result["data/L1/b.parquet"].len(), 1);
+        assert!(result["data/L0/a.parquet"].contains(0));
+        assert!(result["data/L1/b.parquet"].contains(0));
+    }
+
+    #[test]
+    fn new_keys_without_priors_emit_no_dv() {
+        // Memtable keys are entirely new — none have priors in any
+        // file. Result must be empty.
+        let tmp = TempDir::new().unwrap();
+        let f0 = write_file(
+            tmp.path(),
+            "data/L1/a.parquet",
+            (0..16).map(|id| (id, id as u64 + 1)).collect(),
+            Level(1),
+        );
+        let v = version_with_files(HashMap::from([(Level(1), vec![f0])]));
+        // Memtable: ids 100..110 — none in the file's range.
+        let keys: Vec<Vec<u8>> = (100..110).map(user_key).collect();
+        let result = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        assert!(
+            result.is_empty(),
+            "new keys must not emit DV deltas, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn mixed_new_and_upsert_keys_only_priors_marked() {
+        let tmp = TempDir::new().unwrap();
+        let f0 = write_file(
+            tmp.path(),
+            "data/L1/a.parquet",
+            vec![(1, 1), (3, 3), (5, 5), (7, 7)],
+            Level(1),
+        );
+        let v = version_with_files(HashMap::from([(Level(1), vec![f0])]));
+        // Memtable: 1 (upsert), 2 (new), 3 (upsert), 4 (new), 5 (upsert).
+        let keys: Vec<Vec<u8>> = vec![1, 2, 3, 4, 5].into_iter().map(user_key).collect();
+        let result = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema())).unwrap();
+        let bm = &result["data/L1/a.parquet"];
+        // File rows: [1@pos0, 3@pos1, 5@pos2, 7@pos3]. Upserts of
+        // 1, 3, 5 mark positions 0, 1, 2.
+        assert_eq!(bm.len(), 3);
+        assert!(bm.contains(0));
+        assert!(bm.contains(1));
+        assert!(bm.contains(2));
+        // 7@pos3 was NOT upserted, must NOT be marked.
+        assert!(!bm.contains(3));
+    }
+
+    #[test]
+    fn resolver_errors_on_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        // Build the meta for a file that does NOT exist on disk.
+        let bogus = DataFileMeta {
+            path: "data/L1/missing.parquet".to_string(),
+            meta: ParquetFileMeta {
+                level: Level(1),
+                seq_min: 1,
+                seq_max: 10,
+                key_min: user_key(0),
+                key_max: user_key(31),
+                num_rows: 32,
+                file_size: 1024,
+                dv_path: None,
+                dv_offset: None,
+                dv_length: None,
+                format: Some(FileFormat::default_for_level(Level(1))),
+                column_stats: None,
+            },
+            dv_path: None,
+            dv_offset: None,
+            dv_length: None,
+        };
+        let v = version_with_files(HashMap::from([(Level(1), vec![bogus])]));
+        let keys: Vec<Vec<u8>> = (0..16).map(user_key).collect();
+        let err = resolve_dv_for_flush(&keys, &v, tmp.path(), &Arc::new(test_schema()))
+            .expect_err("missing file must fail the resolver");
+        // Surface as Io — we propagate fs::read errors verbatim.
+        assert!(
+            matches!(err, MeruError::Io(_)),
+            "expected Io error, got {err:?}"
+        );
+    }
+}

--- a/crates/merutable/src/engine/engine.rs
+++ b/crates/merutable/src/engine/engine.rs
@@ -1306,6 +1306,20 @@ impl MeruEngine {
                     num_rows: f.meta.num_rows,
                     seq_range: (f.meta.seq_min, f.meta.seq_max),
                     has_dv: f.has_dv(),
+                    // Issue #89: surface DV coords from the version's
+                    // DataFileMeta. has_dv() == true ⇒ all three
+                    // dv_{path,offset,length} are Some by manifest
+                    // invariant; we still defensively bind only when
+                    // every component is present so a corrupt manifest
+                    // entry surfaces as `dv: None` rather than panicking.
+                    dv: match (f.dv_path.as_ref(), f.dv_offset, f.dv_length) {
+                        (Some(p), Some(o), Some(l)) => Some(crate::engine::stats::DvStats {
+                            path: p.clone(),
+                            offset: o,
+                            length: l,
+                        }),
+                        _ => None,
+                    },
                 })
                 .collect();
             levels.push(crate::engine::stats::LevelStats {

--- a/crates/merutable/src/engine/flush.rs
+++ b/crates/merutable/src/engine/flush.rs
@@ -237,6 +237,28 @@ pub async fn run_flush(engine: &Arc<MeruEngine>) -> Result<()> {
     txn.set_prop("merutable.first_seq", first_seq.0.to_string());
     txn.set_prop("merutable.last_seq", last_seq.0.to_string());
 
+    // RFC-0002: build the deduplicated, sorted user_key list once
+    // before commit_lock. The memtable's iter already yields entries
+    // in sorted (user_key ASC, seq DESC) order, so the dedup is a
+    // simple "skip-if-same-as-previous" walk. We do this OUTSIDE the
+    // commit_lock so the lock is held only for the resolve+commit
+    // chain — minimizes contention with concurrent compaction
+    // commits.
+    let dv_user_keys: Vec<Vec<u8>> = if engine.config.enable_flush_dv_emission {
+        let mut out: Vec<Vec<u8>> = Vec::with_capacity(entries.len());
+        let mut prev: Option<&[u8]> = None;
+        for e in &entries {
+            let uk = e.user_key.as_ref();
+            if prev != Some(uk) {
+                out.push(uk.to_vec());
+                prev = Some(uk);
+            }
+        }
+        out
+    } else {
+        Vec::new()
+    };
+
     // Commit snapshot. Serialized with concurrent compaction commits
     // via `commit_lock` — both paths compute `next_ver` from the
     // current manifest and write `v{N+1}.metadata.json`, so two
@@ -244,6 +266,40 @@ pub async fn run_flush(engine: &Arc<MeruEngine>) -> Result<()> {
     // this lock. The commit itself is brief (single fsync chain).
     let new_version = {
         let _commit_guard = engine.commit_lock.lock().await;
+
+        // RFC-0002: resolve flush-time DV deltas under the commit
+        // lock against the current pinned version. Holding
+        // commit_lock guarantees no compaction can replace files
+        // between resolve (computes file:position) and commit
+        // (stamps the DV blob into the new manifest).
+        if !dv_user_keys.is_empty() {
+            let pinned = engine.version_set.current().clone();
+            let base = engine.catalog.base_path().to_path_buf();
+            let schema_for_resolve = engine.schema.clone();
+            let keys_for_resolve = dv_user_keys.clone();
+            // Run on a blocking thread — the resolver does
+            // synchronous fs::read + Parquet decode and would
+            // otherwise stall the tokio runtime.
+            let dv_deltas = tokio::task::spawn_blocking(move || {
+                crate::engine::dv_resolve::resolve_dv_for_flush(
+                    &keys_for_resolve,
+                    &pinned,
+                    &base,
+                    &schema_for_resolve,
+                )
+            })
+            .await
+            .map_err(|e| MeruError::Compaction(format!("flush DV resolve join: {e}")))??;
+
+            for (path, bitmap) in dv_deltas {
+                let mut dv = crate::iceberg::DeletionVector::new();
+                for pos in &bitmap {
+                    dv.mark_deleted(pos);
+                }
+                txn.add_dv(path, dv);
+            }
+        }
+
         // Issue #14 Phase 3: per-commit duration histogram. Sampled
         // once per snapshot; includes the puffin-upload + manifest-
         // write + version-hint-rename chain.

--- a/crates/merutable/src/engine/flush.rs
+++ b/crates/merutable/src/engine/flush.rs
@@ -236,6 +236,21 @@ pub async fn run_flush(engine: &Arc<MeruEngine>) -> Result<()> {
     txn.set_prop("merutable.job", "flush");
     txn.set_prop("merutable.first_seq", first_seq.0.to_string());
     txn.set_prop("merutable.last_seq", last_seq.0.to_string());
+    // Issue #93: snapshot-level marker so external readers (and
+    // operators auditing historical snapshots) can tell whether
+    // this commit's prior-version DVs were emitted at flush time.
+    // Snapshots written before 0.0.2 — or by a writer running with
+    // OpenOptions::enable_flush_dv_emission(false) — won't carry
+    // this prop, signaling that the MVCC dedup projection in
+    // docs/EXTERNAL_READS.md is still required for them.
+    txn.set_prop(
+        "merutable.flush_dv_emission",
+        if engine.config.enable_flush_dv_emission {
+            "true"
+        } else {
+            "false"
+        },
+    );
 
     // RFC-0002: build the deduplicated, sorted user_key list once
     // before commit_lock. The memtable's iter already yields entries

--- a/crates/merutable/src/engine/mod.rs
+++ b/crates/merutable/src/engine/mod.rs
@@ -19,4 +19,4 @@ pub mod write_path;
 
 pub use config::EngineConfig;
 pub use engine::MeruEngine;
-pub use stats::{CacheStats, EngineStats, FileStats, LevelStats, MemtableStats};
+pub use stats::{CacheStats, DvStats, EngineStats, FileStats, LevelStats, MemtableStats};

--- a/crates/merutable/src/engine/mod.rs
+++ b/crates/merutable/src/engine/mod.rs
@@ -3,6 +3,7 @@ pub mod cache;
 pub mod codec;
 pub mod compaction;
 pub mod config;
+pub mod dv_resolve;
 // Issue #38: workspace collapsed; the former crate's `lib.rs` →
 // `mod.rs`, and the former `engine.rs` retains its name to keep
 // the public path `crate::engine::engine::MeruEngine` stable for

--- a/crates/merutable/src/engine/stats.rs
+++ b/crates/merutable/src/engine/stats.rs
@@ -12,6 +12,25 @@ pub struct FileStats {
     pub num_rows: u64,
     pub seq_range: (u64, u64),
     pub has_dv: bool,
+    /// Issue #89: when the file has an associated deletion vector,
+    /// the on-disk Puffin coords as recorded in the manifest. `None`
+    /// when `has_dv == false`. Cheap — populated from the version's
+    /// in-memory `DataFileMeta` with no extra I/O. Cardinality is
+    /// NOT included here (it would require opening the puffin blob);
+    /// callers that need it can read the blob via these coords.
+    pub dv: Option<DvStats>,
+}
+
+/// On-disk coords for a single Puffin DV blob. Surfaced in
+/// `FileStats::dv` for files that have a DV.
+#[derive(Debug, Clone)]
+pub struct DvStats {
+    /// Object-store-relative path of the `.puffin` file.
+    pub path: String,
+    /// Byte offset of the DV blob within the puffin file.
+    pub offset: i64,
+    /// Byte length of the DV blob.
+    pub length: i64,
 }
 
 /// Per-level statistics.

--- a/crates/merutable/src/options.rs
+++ b/crates/merutable/src/options.rs
@@ -140,6 +140,13 @@ pub struct OpenOptions {
     /// Issue #31: optional async mirror to an object-store target.
     /// See [`MirrorConfig`].
     pub mirror: Option<MirrorConfig>,
+
+    /// RFC-0002: emit per-file deletion vectors at flush time so
+    /// every prior version of each upserted/deleted memtable key is
+    /// DV-marked. Required for external Iceberg readers to see one
+    /// row per primary key without an MVCC dedup projection.
+    /// Default: `true`.
+    pub enable_flush_dv_emission: bool,
 }
 
 impl OpenOptions {
@@ -172,6 +179,7 @@ impl OpenOptions {
             read_only: ec.read_only,
             dual_format_max_level: ec.dual_format_max_level,
             mirror: None,
+            enable_flush_dv_emission: ec.enable_flush_dv_emission,
         }
     }
 
@@ -188,6 +196,14 @@ impl OpenOptions {
     /// level columnar-only for OLAP / append-only.
     pub fn dual_format_max_level(mut self, max: Option<u8>) -> Self {
         self.dual_format_max_level = max;
+        self
+    }
+
+    /// RFC-0002: toggle flush-time deletion-vector emission. Default
+    /// is `true`; set `false` to skip the resolve+emit step (e.g. for
+    /// workloads with no upserts where the cost is pure overhead).
+    pub fn enable_flush_dv_emission(mut self, on: bool) -> Self {
+        self.enable_flush_dv_emission = on;
         self
     }
 

--- a/crates/merutable/src/parquet/codec.rs
+++ b/crates/merutable/src/parquet/codec.rs
@@ -327,6 +327,45 @@ fn field_variant_name(v: &FieldValue) -> &'static str {
     }
 }
 
+/// Decode the `_merutable_ikey` column from a `RecordBatch` into a
+/// `Vec<InternalKey>`, **without** materializing per-column field
+/// values or the postcard blob.
+///
+/// Used by the flush-time deletion-vector resolve path
+/// (`ParquetReader::iter_user_keys_in_range`), where the consumer
+/// only needs `(user_key, file_position)` and pays nothing for the
+/// row payload it would discard. The batch must include
+/// `_merutable_ikey`; other columns are ignored.
+///
+/// The `_merutable_ikey` column is encoded as `BinaryArray` and is
+/// `not nullable` (asserted by the writer's `arrow_schema`), so a
+/// missing/null entry is corruption.
+pub fn record_batch_to_ikeys(
+    batch: &RecordBatch,
+    schema: &TableSchema,
+) -> Result<Vec<InternalKey>> {
+    let n = batch.num_rows();
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+    let arrow_schema = batch.schema();
+    let ikey_idx = arrow_schema
+        .index_of(IKEY_COLUMN_NAME)
+        .map_err(|_| MeruError::Parquet(format!("missing {IKEY_COLUMN_NAME} column")))?;
+    let ikey_col = batch
+        .column(ikey_idx)
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .ok_or_else(|| MeruError::Parquet(format!("{IKEY_COLUMN_NAME} not BinaryArray")))?;
+
+    let mut out = Vec::with_capacity(n);
+    for row_idx in 0..n {
+        let ikey_bytes = ikey_col.value(row_idx);
+        out.push(InternalKey::decode(ikey_bytes, schema)?);
+    }
+    Ok(out)
+}
+
 /// Convert an Arrow `RecordBatch` (from a Parquet read) back into
 /// `(InternalKey, Row)` pairs.
 ///

--- a/crates/merutable/src/parquet/reader.rs
+++ b/crates/merutable/src/parquet/reader.rs
@@ -465,6 +465,247 @@ impl<R: ChunkReader + Clone + 'static> ParquetReader<R> {
         Ok(out)
     }
 
+    /// Streaming iterator over `(user_key_bytes, file_global_row_position)`
+    /// pairs whose `user_key` falls within `[lo, hi]` (inclusive on both
+    /// ends), in the file's natural sort order — `(user_key ASC, seq DESC)`.
+    ///
+    /// This is the read-side primitive for **flush-time deletion vector
+    /// resolution** (RFC-0002). The flush job range-merges the memtable
+    /// keys against this iterator to find every prior position of every
+    /// upserted key — without decoding the row payload.
+    ///
+    /// Properties:
+    ///
+    /// 1. **Disjoint range = zero I/O.** If `[lo, hi]` does not overlap
+    ///    the file's `key_min..=key_max`, the returned iterator yields
+    ///    nothing and the file's data pages are never opened. Asserted
+    ///    by `iter_user_keys_disjoint_range_yields_empty_no_io`.
+    /// 2. **Lazy.** Constructing the iterator (and dropping it without
+    ///    pulling) only walks the in-memory `KvSparseIndex` to compute
+    ///    the candidate page set — no data-page reads happen until the
+    ///    first `next()`. The constructor is allowed to error, but
+    ///    must not perform Parquet I/O on disjoint inputs.
+    /// 3. **Multi-version yield.** A `user_key` with N versions in the
+    ///    file yields N tuples — one per InternalKey occurrence —
+    ///    in `seq DESC` order (the natural file order). The caller
+    ///    (`engine::dv_resolve`) marks every position so an upsert
+    ///    DV-marks every prior version, not just the latest.
+    /// 4. **No row decode.** Only the `_merutable_ikey` column is
+    ///    projected. Per-column field extraction and postcard blob
+    ///    decode are skipped — saves both CPU and column-chunk I/O at
+    ///    L1+ where typed columns dominate the file size.
+    /// 5. **Fallback for kv-index-less files.** Files written without
+    ///    `merutable.kv_index.v1` (legacy or empty) fall through to a
+    ///    full-file scan, then in-memory filter. Correct, slower; the
+    ///    fast path is the kv_index-driven page selection.
+    pub fn iter_user_keys_in_range<'a>(
+        &'a self,
+        lo: &[u8],
+        hi: &[u8],
+    ) -> Result<RangeKeyIter<'a, R>> {
+        // Cheap range-disjoint check first — if the file's recorded
+        // key bounds don't overlap [lo, hi], short-circuit with no
+        // page work at all. The bounds are byte-comparable per
+        // InternalKey's encoding (user_key prefix dominates).
+        let disjoint = (!self.meta.key_min.is_empty() && hi < self.meta.key_min.as_slice())
+            || (!self.meta.key_max.is_empty() && lo > self.meta.key_max.as_slice())
+            || lo > hi; // caller-supplied empty range
+        if disjoint {
+            return Ok(RangeKeyIter {
+                reader: self,
+                lo: Vec::new(),
+                hi: Vec::new(),
+                pages: Vec::new(),
+                next_page_idx: 0,
+                buffer: std::collections::VecDeque::new(),
+                fallback_done: true, // no work to do
+            });
+        }
+
+        // No kv_index: full-file scan fallback. Defer the actual scan
+        // to first `next()` so this constructor stays I/O-free on
+        // construction (lazy contract).
+        if self.kv_index.is_none() {
+            return Ok(RangeKeyIter {
+                reader: self,
+                lo: lo.to_vec(),
+                hi: hi.to_vec(),
+                pages: Vec::new(),
+                next_page_idx: 0,
+                buffer: std::collections::VecDeque::new(),
+                fallback_done: false,
+            });
+        }
+
+        // kv_index path: walk the in-memory index entries to compute
+        // the set of pages whose key range overlaps [lo, hi]. Each
+        // entry covers `[entry.key, next_entry.key)` (or `[entry.key,
+        // file_end)` for the last entry). A page is needed iff:
+        //   - entry.key <= hi          (otherwise above the window)
+        //   - next.key  >  lo          (otherwise entirely below it)
+        //                              (no `next` ⇒ last page, include
+        //                              if entry.key <= hi).
+        //
+        // We collect (PageLocation, next_first_row) so the per-page
+        // read function can clamp to row-group boundaries the same way
+        // `read_rows_in_page` does.
+        let entries: Vec<(Vec<u8>, PageLocation)> =
+            self.kv_index.as_ref().unwrap().iter().collect();
+        let mut pages: Vec<(PageLocation, Option<u64>)> = Vec::new();
+        for i in 0..entries.len() {
+            let (entry_key, page_loc) = &entries[i];
+            // entry_key is a full InternalKey byte string; we compare
+            // against `hi` (a user_key). InternalKey encoding places
+            // user_key bytes first then an 8-byte seq/op trailer, so
+            // an InternalKey starting with bytes > hi is unambiguously
+            // above hi in user-key order. The reverse — entry_key
+            // starts with bytes <= hi — does NOT prove the page is
+            // needed (its first key may have user_key == hi but
+            // trailer bytes that make the full InternalKey compare
+            // greater than `hi`-with-zero-trailer); we let the
+            // per-page filter handle that boundary case correctly.
+            let entry_uk = ikey_user_key_prefix(entry_key);
+            if entry_uk.as_slice() > hi {
+                break; // this page and every later page start above hi
+            }
+            // Skip pages entirely below lo: covered when next entry
+            // exists and its first user_key is <= lo (page i ends at
+            // next entry's start, exclusive).
+            if let Some((next_key, _)) = entries.get(i + 1) {
+                let next_uk = ikey_user_key_prefix(next_key);
+                if next_uk.as_slice() <= lo {
+                    continue;
+                }
+            }
+            let next_first_row = entries.get(i + 1).map(|(_, loc)| loc.first_row_index);
+            pages.push((*page_loc, next_first_row));
+        }
+
+        Ok(RangeKeyIter {
+            reader: self,
+            lo: lo.to_vec(),
+            hi: hi.to_vec(),
+            pages,
+            next_page_idx: 0,
+            buffer: std::collections::VecDeque::new(),
+            fallback_done: true, // no fallback needed when kv_index drove selection
+        })
+    }
+
+    /// ikey-only counterpart of `read_rows_in_page`. Same row-group
+    /// math; projects only `_merutable_ikey` so the value blob /
+    /// typed user columns are never decoded. Returns
+    /// `(InternalKey, file_global_position)` per row in page order.
+    fn read_ikeys_in_page(
+        &self,
+        page_loc: PageLocation,
+        next_first_row: Option<u64>,
+    ) -> Result<Vec<(InternalKey, u64)>> {
+        let builder = ParquetRecordBatchReaderBuilder::try_new(self.source.clone())
+            .map_err(|e| MeruError::Parquet(e.to_string()))?;
+
+        let metadata = builder.metadata().clone();
+        let mut cum: u64 = 0;
+        let mut found: Option<(usize, u64, u64)> = None;
+        for (rg_idx, rg) in metadata.row_groups().iter().enumerate() {
+            let rg_num_rows = rg.num_rows();
+            if rg_num_rows < 0 {
+                return Err(MeruError::Corruption(format!(
+                    "negative num_rows {} in row group {rg_idx}",
+                    rg_num_rows
+                )));
+            }
+            let rg_rows = rg_num_rows as u64;
+            let rg_start = cum;
+            let rg_end = cum + rg_rows;
+            if page_loc.first_row_index >= rg_start && page_loc.first_row_index < rg_end {
+                found = Some((rg_idx, rg_start, rg_end));
+                break;
+            }
+            cum = rg_end;
+        }
+        let (rg_idx, rg_start, rg_end) = found.ok_or_else(|| {
+            MeruError::Parquet(format!(
+                "kv_index page first_row_index {} out of range for file row count {}",
+                page_loc.first_row_index, cum
+            ))
+        })?;
+
+        let upper = match next_first_row {
+            Some(n) if n <= rg_end => n,
+            _ => rg_end,
+        };
+        let page_row_count = (upper - page_loc.first_row_index) as usize;
+        let intra_rg_offset = (page_loc.first_row_index - rg_start) as usize;
+
+        let mask = self.ikey_only_projection_mask(builder.parquet_schema())?;
+        let mut selectors: Vec<RowSelector> = Vec::with_capacity(2);
+        if intra_rg_offset > 0 {
+            selectors.push(RowSelector::skip(intra_rg_offset));
+        }
+        if page_row_count == 0 {
+            return Ok(Vec::new());
+        }
+        selectors.push(RowSelector::select(page_row_count));
+        let selection = RowSelection::from(selectors);
+
+        let reader = builder
+            .with_row_groups(vec![rg_idx])
+            .with_projection(mask)
+            .with_row_selection(selection)
+            .build()
+            .map_err(|e| MeruError::Parquet(e.to_string()))?;
+
+        let mut out: Vec<(InternalKey, u64)> = Vec::with_capacity(page_row_count);
+        let mut row_offset = page_loc.first_row_index;
+        for batch_result in reader {
+            let batch = batch_result.map_err(|e| MeruError::Parquet(e.to_string()))?;
+            let ikeys = codec::record_batch_to_ikeys(&batch, &self.schema)?;
+            for ik in ikeys {
+                out.push((ik, row_offset));
+                row_offset += 1;
+            }
+        }
+        Ok(out)
+    }
+
+    /// ikey-only full-file scan. Fallback for files lacking
+    /// `merutable.kv_index.v1`. Returns every InternalKey in file
+    /// order with its global row index.
+    fn read_all_ikeys(&self) -> Result<Vec<(InternalKey, u64)>> {
+        let builder = ParquetRecordBatchReaderBuilder::try_new(self.source.clone())
+            .map_err(|e| MeruError::Parquet(e.to_string()))?;
+
+        let mask = self.ikey_only_projection_mask(builder.parquet_schema())?;
+        let reader = builder
+            .with_projection(mask)
+            .build()
+            .map_err(|e| MeruError::Parquet(e.to_string()))?;
+
+        let mut out: Vec<(InternalKey, u64)> = Vec::with_capacity(self.meta.num_rows as usize);
+        let mut row_offset: u64 = 0;
+        for batch_result in reader {
+            let batch = batch_result.map_err(|e| MeruError::Parquet(e.to_string()))?;
+            let ikeys = codec::record_batch_to_ikeys(&batch, &self.schema)?;
+            for ik in ikeys {
+                out.push((ik, row_offset));
+                row_offset += 1;
+            }
+        }
+        Ok(out)
+    }
+
+    /// Single-leaf projection of `_merutable_ikey` only. Skips both
+    /// the L0 `_merutable_value` blob and L1+ typed columns — DV
+    /// resolution doesn't need any of them.
+    fn ikey_only_projection_mask(
+        &self,
+        parquet_schema: &parquet::schema::types::SchemaDescriptor,
+    ) -> Result<ProjectionMask> {
+        let leaf = find_leaf(parquet_schema, IKEY_COLUMN_NAME)?;
+        Ok(ProjectionMask::leaves(parquet_schema, vec![leaf]))
+    }
+
     /// Build the level-aware leaf-column projection mask used by both
     /// `read_all_rows` and `read_rows_in_page`. At L0 we project only
     /// `[_merutable_ikey, _merutable_value]` (the postcard fast path); at
@@ -519,6 +760,90 @@ fn find_leaf(schema: &parquet::schema::types::SchemaDescriptor, name: &str) -> R
 /// the codec fills with a default.
 fn find_leaf_opt(schema: &parquet::schema::types::SchemaDescriptor, name: &str) -> Option<usize> {
     (0..schema.num_columns()).find(|&i| schema.column(i).name() == name)
+}
+
+/// Strip the InternalKey 8-byte trailer to expose the user_key prefix.
+/// Defensive: if the input is shorter than 8 bytes, returns the input
+/// unchanged (a malformed kv_index entry will surface as a downstream
+/// decode error rather than a panic here).
+fn ikey_user_key_prefix(ikey_bytes: &[u8]) -> Vec<u8> {
+    if ikey_bytes.len() < 8 {
+        return ikey_bytes.to_vec();
+    }
+    ikey_bytes[..ikey_bytes.len() - 8].to_vec()
+}
+
+/// Lazy iterator over `(user_key_bytes, file_global_position)` pairs
+/// in `[lo, hi]`, returned by [`ParquetReader::iter_user_keys_in_range`].
+///
+/// State machine:
+/// - **kv_index path** — `pages` is pre-computed (cheap in-memory
+///   walk); `next_page_idx` advances as pages are consumed; `buffer`
+///   is the decoded ikeys from the current page, drained on each
+///   `next()`. `fallback_done = true`.
+/// - **Full-file fallback path** — `pages` is empty; `fallback_done`
+///   starts `false`; on the first `next()` we read every ikey in the
+///   file, filter to `[lo, hi]`, and load `buffer` once.
+/// - **Disjoint short-circuit** — `pages` empty AND `fallback_done = true`
+///   AND `buffer` empty ⇒ iterator yields nothing, never touches I/O.
+///
+/// The iterator borrows `&'a ParquetReader<R>` so the buffered
+/// `source: R` stays alive for the lifetime of the scan.
+pub struct RangeKeyIter<'a, R: ChunkReader + Clone> {
+    reader: &'a ParquetReader<R>,
+    lo: Vec<u8>,
+    hi: Vec<u8>,
+    pages: Vec<(PageLocation, Option<u64>)>,
+    next_page_idx: usize,
+    buffer: std::collections::VecDeque<(Vec<u8>, u64)>,
+    fallback_done: bool,
+}
+
+impl<'a, R: ChunkReader + Clone + 'static> Iterator for RangeKeyIter<'a, R> {
+    type Item = Result<(Vec<u8>, u64)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(item) = self.buffer.pop_front() {
+                return Some(Ok(item));
+            }
+            // Buffer empty: refill from next page (kv_index path) or
+            // from the one-shot full-file scan (fallback path).
+            if self.next_page_idx < self.pages.len() {
+                let (page_loc, next_first_row) = self.pages[self.next_page_idx];
+                self.next_page_idx += 1;
+                match self.reader.read_ikeys_in_page(page_loc, next_first_row) {
+                    Ok(rows) => {
+                        for (ik, pos) in rows {
+                            let uk = ik.user_key_bytes();
+                            // Inclusive [lo, hi] filter on user_key.
+                            if uk >= self.lo.as_slice() && uk <= self.hi.as_slice() {
+                                self.buffer.push_back((uk.to_vec(), pos));
+                            }
+                        }
+                        continue; // try buffer again
+                    }
+                    Err(e) => return Some(Err(e)),
+                }
+            }
+            if !self.fallback_done {
+                self.fallback_done = true;
+                match self.reader.read_all_ikeys() {
+                    Ok(rows) => {
+                        for (ik, pos) in rows {
+                            let uk = ik.user_key_bytes();
+                            if uk >= self.lo.as_slice() && uk <= self.hi.as_slice() {
+                                self.buffer.push_back((uk.to_vec(), pos));
+                            }
+                        }
+                        continue;
+                    }
+                    Err(e) => return Some(Err(e)),
+                }
+            }
+            return None; // exhausted
+        }
+    }
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -1332,5 +1657,267 @@ mod tests {
         .unwrap();
         assert!(bytes.is_empty());
         assert_eq!(meta.num_rows, 0);
+    }
+
+    // ── iter_user_keys_in_range tests (RFC-0002 Phase 1) ─────────────────────
+
+    /// Build a deterministic file with `id ∈ [first_id, first_id + count)`,
+    /// each at `seq = id` (so positions and ids align). Single-version
+    /// per key.
+    fn write_id_sequence(first_id: i64, count: usize) -> (Vec<u8>, TableSchema) {
+        let schema = test_schema();
+        let mut rows = Vec::with_capacity(count);
+        for offset in 0..count {
+            let id = first_id + offset as i64;
+            let ikey = make_ikey(id, id as u64);
+            let row = Row::new(vec![
+                Some(FieldValue::Int64(id)),
+                Some(FieldValue::Bytes(BBytes::from(format!("v{id}")))),
+            ]);
+            rows.push((ikey, row));
+        }
+        let bytes = write_test_file(rows, &schema);
+        (bytes, schema)
+    }
+
+    /// Encode a probe user_key for `id` (matches `make_ikey`'s PK
+    /// encoding). Useful for `iter_user_keys_in_range(lo, hi)`
+    /// constructing comparable user_key bounds.
+    fn user_key_for(id: i64) -> Vec<u8> {
+        let ik = make_ikey(id, 0);
+        ik.user_key_bytes().to_vec()
+    }
+
+    #[test]
+    fn iter_user_keys_full_range_yields_every_position() {
+        let (bytes, schema) = write_id_sequence(0, 64);
+        let reader = ParquetReader::open(BBytes::from(bytes), Arc::new(schema)).unwrap();
+
+        let lo = user_key_for(i64::MIN);
+        let hi = user_key_for(i64::MAX);
+        let collected: Vec<(Vec<u8>, u64)> = reader
+            .iter_user_keys_in_range(&lo, &hi)
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        assert_eq!(
+            collected.len(),
+            64,
+            "every row must be yielded exactly once"
+        );
+        // Positions are 0..64 in order — the file is single-version sorted ASC.
+        for (i, (uk, pos)) in collected.iter().enumerate() {
+            assert_eq!(*pos, i as u64, "position {i} mismatch");
+            assert_eq!(uk, &user_key_for(i as i64), "user_key {i} mismatch");
+        }
+    }
+
+    #[test]
+    fn iter_user_keys_partial_range_yields_only_overlap() {
+        let (bytes, schema) = write_id_sequence(0, 64);
+        let reader = ParquetReader::open(BBytes::from(bytes), Arc::new(schema)).unwrap();
+
+        // Restrict to id ∈ [10, 20] inclusive on both ends.
+        let lo = user_key_for(10);
+        let hi = user_key_for(20);
+        let collected: Vec<(Vec<u8>, u64)> = reader
+            .iter_user_keys_in_range(&lo, &hi)
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        // Tight equality: exactly 11 rows (10..=20), positions 10..=20.
+        assert_eq!(collected.len(), 11);
+        let pos: Vec<u64> = collected.iter().map(|(_, p)| *p).collect();
+        assert_eq!(pos, (10u64..=20).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn iter_user_keys_disjoint_range_above_yields_empty_no_io() {
+        let (bytes, schema) = write_id_sequence(0, 64);
+        // Wrap source in a counting reader to assert zero I/O.
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counted = CountingBytes::new(BBytes::from(bytes), counter.clone());
+        let reader = ParquetReader::open(counted, Arc::new(schema)).unwrap();
+
+        // Reset after open() — open reads the footer; we only care
+        // about post-construction I/O.
+        let baseline = counter.load(std::sync::atomic::Ordering::SeqCst);
+
+        let lo = user_key_for(1000); // far above the id range [0..64)
+        let hi = user_key_for(2000);
+        let iter = reader.iter_user_keys_in_range(&lo, &hi).unwrap();
+        // Construction MUST be I/O-free for disjoint ranges.
+        assert_eq!(
+            counter.load(std::sync::atomic::Ordering::SeqCst),
+            baseline,
+            "disjoint-range constructor must not perform I/O"
+        );
+        let collected: Vec<_> = iter.map(|r| r.unwrap()).collect();
+        assert!(collected.is_empty(), "disjoint range must yield nothing");
+        // Pulling the iterator on a disjoint range MUST also be I/O-free.
+        assert_eq!(
+            counter.load(std::sync::atomic::Ordering::SeqCst),
+            baseline,
+            "disjoint-range pull must not perform I/O"
+        );
+    }
+
+    #[test]
+    fn iter_user_keys_disjoint_range_below_yields_empty() {
+        let (bytes, schema) = write_id_sequence(100, 64);
+        let reader = ParquetReader::open(BBytes::from(bytes), Arc::new(schema)).unwrap();
+        let lo = user_key_for(0);
+        let hi = user_key_for(50); // entirely below [100..164)
+        let collected: Vec<_> = reader
+            .iter_user_keys_in_range(&lo, &hi)
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert!(collected.is_empty());
+    }
+
+    #[test]
+    fn iter_user_keys_inverted_range_yields_empty() {
+        let (bytes, schema) = write_id_sequence(0, 16);
+        let reader = ParquetReader::open(BBytes::from(bytes), Arc::new(schema)).unwrap();
+        let lo = user_key_for(10);
+        let hi = user_key_for(5); // hi < lo
+        let collected: Vec<_> = reader
+            .iter_user_keys_in_range(&lo, &hi)
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert!(collected.is_empty());
+    }
+
+    #[test]
+    fn iter_user_keys_single_key_range() {
+        let (bytes, schema) = write_id_sequence(0, 64);
+        let reader = ParquetReader::open(BBytes::from(bytes), Arc::new(schema)).unwrap();
+        let lo = user_key_for(42);
+        let hi = lo.clone();
+        let collected: Vec<_> = reader
+            .iter_user_keys_in_range(&lo, &hi)
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0].1, 42, "position");
+        assert_eq!(collected[0].0, lo, "user_key");
+    }
+
+    #[test]
+    fn iter_user_keys_yields_every_version_of_multiversion_key() {
+        // Same id at three different seqs — file order is
+        // (user_key ASC, seq DESC), so positions 0,1,2 carry seqs
+        // 30, 20, 10 for id=7. All three positions must be yielded.
+        let schema = test_schema();
+        let id: i64 = 7;
+        let mut rows = Vec::new();
+        for &seq in &[30u64, 20, 10] {
+            let ikey = make_ikey(id, seq);
+            let row = Row::new(vec![
+                Some(FieldValue::Int64(id)),
+                Some(FieldValue::Bytes(BBytes::from(format!("v{seq}")))),
+            ]);
+            rows.push((ikey, row));
+        }
+        let bytes = write_test_file(rows, &schema);
+        let reader = ParquetReader::open(BBytes::from(bytes), Arc::new(schema)).unwrap();
+
+        let uk = user_key_for(id);
+        let collected: Vec<_> = reader
+            .iter_user_keys_in_range(&uk, &uk)
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(collected.len(), 3, "every version must yield");
+        assert_eq!(
+            collected.iter().map(|(_, p)| *p).collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+        for (yielded_uk, _) in &collected {
+            assert_eq!(yielded_uk, &uk);
+        }
+    }
+
+    #[test]
+    fn iter_user_keys_lazy_construction_is_io_free() {
+        // Sanity check the lazy-construction property for an
+        // OVERLAPPING range too: building the iterator (kv_index
+        // page-set computation) must not touch data pages.
+        let (bytes, schema) = write_id_sequence(0, 64);
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counted = CountingBytes::new(BBytes::from(bytes), counter.clone());
+        let reader = ParquetReader::open(counted, Arc::new(schema)).unwrap();
+        let baseline = counter.load(std::sync::atomic::Ordering::SeqCst);
+
+        let lo = user_key_for(20);
+        let hi = user_key_for(30);
+        let iter = reader.iter_user_keys_in_range(&lo, &hi).unwrap();
+        // Constructing must NOT have read any data pages — the
+        // kv_index walk happens entirely against the in-memory
+        // index decoded at `open` time.
+        assert_eq!(
+            counter.load(std::sync::atomic::Ordering::SeqCst),
+            baseline,
+            "iterator construction must be I/O-free"
+        );
+        // Drop without pulling — still no I/O.
+        drop(iter);
+        assert_eq!(
+            counter.load(std::sync::atomic::Ordering::SeqCst),
+            baseline,
+            "dropping unpulled iterator must be I/O-free"
+        );
+
+        // Now pull — I/O must happen.
+        let _: Vec<_> = reader
+            .iter_user_keys_in_range(&lo, &hi)
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert!(
+            counter.load(std::sync::atomic::Ordering::SeqCst) > baseline,
+            "pulling must trigger reads"
+        );
+    }
+
+    /// Counting wrapper around `Bytes` to assert zero-I/O paths.
+    /// Implements `ChunkReader` + `Length` by delegating to `Bytes`
+    /// while incrementing a counter on every `get_bytes` / `get_read`
+    /// call.
+    #[derive(Clone)]
+    struct CountingBytes {
+        inner: BBytes,
+        counter: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl CountingBytes {
+        fn new(inner: BBytes, counter: std::sync::Arc<std::sync::atomic::AtomicUsize>) -> Self {
+            Self { inner, counter }
+        }
+    }
+
+    impl parquet::file::reader::Length for CountingBytes {
+        fn len(&self) -> u64 {
+            self.inner.len() as u64
+        }
+    }
+
+    impl parquet::file::reader::ChunkReader for CountingBytes {
+        type T = bytes::buf::Reader<BBytes>;
+        fn get_read(&self, start: u64) -> parquet::errors::Result<Self::T> {
+            self.counter
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.inner.get_read(start)
+        }
+        fn get_bytes(&self, start: u64, length: usize) -> parquet::errors::Result<BBytes> {
+            self.counter
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.inner.get_bytes(start, length)
+        }
     }
 }

--- a/crates/merutable/tests/stress_flush_dv.rs
+++ b/crates/merutable/tests/stress_flush_dv.rs
@@ -1,0 +1,448 @@
+//! RFC-0002 stress + chaos tests for flush-time DV emission.
+//!
+//! These tests run as integration tests (separate binary), so they
+//! exercise the full public API surface — `MeruDB::open`, `put`,
+//! `delete`, `get`, `scan`, `flush`, `compact`, `close` — under
+//! workloads designed to trip the resolve+commit ordering, the
+//! L0/L1+ DV merge, and the read-side dedup invariants.
+//!
+//! Bounded resources (per CLAUDE.md):
+//! - Iteration count caps the stress duration deterministically.
+//!   No "run for 60s" loops that flake on CI.
+//! - Concurrency is fixed at K worker tasks, not unbounded.
+//! - Memory: memtable_size_mb=1 keeps the per-test footprint < 16 MiB.
+
+use bytes::Bytes;
+use merutable::schema::{ColumnDef, ColumnType, TableSchema};
+use merutable::value::{FieldValue, Row};
+use merutable::{MeruDB, OpenOptions};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use tempfile::TempDir;
+
+fn schema() -> TableSchema {
+    TableSchema {
+        table_name: "stress".into(),
+        columns: vec![
+            ColumnDef {
+                name: "id".into(),
+                col_type: ColumnType::Int64,
+                nullable: false,
+                ..Default::default()
+            },
+            ColumnDef {
+                name: "version".into(),
+                col_type: ColumnType::Int64,
+                nullable: false,
+                ..Default::default()
+            },
+            ColumnDef {
+                name: "payload".into(),
+                col_type: ColumnType::ByteArray,
+                nullable: true,
+                ..Default::default()
+            },
+        ],
+        primary_key: vec![0],
+        ..Default::default()
+    }
+}
+
+fn make_row(id: i64, version: i64, payload: &str) -> Row {
+    Row::new(vec![
+        Some(FieldValue::Int64(id)),
+        Some(FieldValue::Int64(version)),
+        Some(FieldValue::Bytes(Bytes::from(payload.to_string()))),
+    ])
+}
+
+fn open(tmp: &TempDir) -> OpenOptions {
+    OpenOptions::new(schema())
+        .wal_dir(tmp.path().join("wal"))
+        .catalog_uri(tmp.path().to_string_lossy().to_string())
+        .memtable_size_mb(1)
+        .gc_grace_period_secs(0)
+}
+
+/// Sum of DV cardinality across every `.puffin` file in the catalog
+/// **as observed by an external reader**. Walks `{catalog}/data/L*`
+/// for `.puffin` files, parses each blob, and sums cardinalities.
+///
+/// External-view (no internal accessors) by design — proves the DV
+/// state is durable on disk in the shape an external Iceberg reader
+/// would consume, not just in-memory state.
+async fn total_dv_cardinality(db: &MeruDB) -> u64 {
+    use merutable::iceberg::DeletionVector;
+    let base = std::path::PathBuf::from(db.catalog_path()).join("data");
+    let mut total: u64 = 0;
+    for level_dir in walk_dirs(&base) {
+        for entry in std::fs::read_dir(&level_dir).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.extension().map(|e| e == "puffin").unwrap_or(false) {
+                let bytes = tokio::fs::read(&path).await.unwrap();
+                // A puffin file may contain multiple blobs; the DV
+                // helper consumes one blob's bytes. We scan with the
+                // referenced_data_file API to discover blob ranges,
+                // but for the simple flush-emitted layout (one DV
+                // blob per puffin file) the whole file IS one blob's
+                // raw bytes wrapped in the PFA1 envelope. The
+                // catalog's writer emits exactly this shape, so
+                // from_puffin_bytes (whole-file decode) round-trips.
+                if let Ok(dv) = DeletionVector::from_puffin_bytes(&bytes) {
+                    total += dv.cardinality();
+                }
+            }
+        }
+    }
+    total
+}
+
+fn walk_dirs(base: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(base) {
+        for entry in rd.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                out.push(p);
+            }
+        }
+    }
+    out
+}
+
+// ── Scenario 1: large upsert sweep ───────────────────────────────────────────
+
+/// Large monotonic upsert workload: write N keys, flush, then upsert
+/// every key with a new version, flush, repeat for several rounds.
+/// Asserts:
+/// - Final read returns exactly the latest version of every key.
+/// - DV cardinality across the snapshot covers every prior version
+///   (so external Iceberg readers would see one row per PK).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stress_repeated_upsert_sweep_preserves_pk_uniqueness() {
+    let tmp = TempDir::new().unwrap();
+    let db = MeruDB::open(open(&tmp)).await.unwrap();
+
+    const N_KEYS: i64 = 500;
+    const ROUNDS: i64 = 5;
+    for round in 0..ROUNDS {
+        for id in 0..N_KEYS {
+            db.put(make_row(id, round, &format!("r{round}_id{id}")))
+                .await
+                .unwrap();
+        }
+        db.flush().await.unwrap();
+    }
+
+    // Every key reads back the LAST round's value.
+    for id in 0..N_KEYS {
+        let row = db.get(&[FieldValue::Int64(id)]).unwrap().unwrap();
+        let version = row.get(1).unwrap();
+        assert_eq!(
+            *version,
+            FieldValue::Int64(ROUNDS - 1),
+            "key {id} must read latest round"
+        );
+    }
+    // Range scan returns exactly N_KEYS rows.
+    let rows = db.scan(None, None).unwrap();
+    assert_eq!(rows.len() as i64, N_KEYS, "scan cardinality");
+
+    // Every prior version got DV-marked. Each round after round 0
+    // marks N_KEYS positions in prior files. Total DVs = (ROUNDS-1)*N_KEYS.
+    let card = total_dv_cardinality(&db).await;
+    assert_eq!(
+        card,
+        ((ROUNDS - 1) as u64) * (N_KEYS as u64),
+        "every prior version must be DV-marked"
+    );
+
+    db.close().await.unwrap();
+}
+
+// ── Scenario 2: interleaved upsert + delete + readback ───────────────────────
+
+/// Interleaved write workload: each round upserts half the keys
+/// and deletes the other half, then flushes. The reads must reflect
+/// the last operation per key.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stress_interleaved_upsert_delete_round_robin() {
+    let tmp = TempDir::new().unwrap();
+    let db = MeruDB::open(open(&tmp)).await.unwrap();
+
+    const N_KEYS: i64 = 200;
+    // Round 0: insert all.
+    for id in 0..N_KEYS {
+        db.put(make_row(id, 0, "init")).await.unwrap();
+    }
+    db.flush().await.unwrap();
+
+    // Track the oracle: (id → last_op).
+    enum Op {
+        Upsert(i64),
+        Deleted,
+    }
+    let mut oracle: BTreeMap<i64, Op> = (0..N_KEYS).map(|id| (id, Op::Upsert(0))).collect();
+
+    // Three rounds. Even ids upserted, odd ids deleted; then swap.
+    for round in 1..=3 {
+        for id in 0..N_KEYS {
+            let upsert_this_round = (id + round) % 2 == 0;
+            if upsert_this_round {
+                db.put(make_row(id, round, &format!("r{round}")))
+                    .await
+                    .unwrap();
+                oracle.insert(id, Op::Upsert(round));
+            } else {
+                db.delete(vec![FieldValue::Int64(id)]).await.unwrap();
+                oracle.insert(id, Op::Deleted);
+            }
+        }
+        db.flush().await.unwrap();
+    }
+
+    // Verify reads against the oracle. Tight equality.
+    for id in 0..N_KEYS {
+        let observed = db.get(&[FieldValue::Int64(id)]).unwrap();
+        match oracle[&id] {
+            Op::Deleted => assert!(observed.is_none(), "key {id} must read None"),
+            Op::Upsert(v) => {
+                let row = observed.unwrap_or_else(|| panic!("key {id} expected version {v}"));
+                let version = row.get(1).unwrap();
+                assert_eq!(*version, FieldValue::Int64(v), "key {id} version mismatch");
+            }
+        }
+    }
+
+    db.close().await.unwrap();
+}
+
+// ── Scenario 3: chaos: concurrent put + flush + compact + scan ──────────────
+
+/// Chaos test: K concurrent tasks each writing into the same DB,
+/// with periodic flush + compact + scan from a separate task.
+/// The point-lookup oracle must still match the last write per key.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn chaos_concurrent_put_flush_compact_scan() {
+    let tmp = TempDir::new().unwrap();
+    let db = Arc::new(MeruDB::open(open(&tmp)).await.unwrap());
+
+    const N_WRITERS: usize = 4;
+    const KEYS_PER_WRITER: i64 = 250;
+    const ROUNDS: i64 = 3;
+
+    let mut writer_handles = Vec::new();
+    for w in 0..N_WRITERS {
+        let db = db.clone();
+        let writer_id = w as i64;
+        writer_handles.push(tokio::spawn(async move {
+            // Each writer owns a disjoint id range so no inter-writer
+            // races; we exercise concurrent writes WITH concurrent
+            // flush/compact/scan, not concurrent multi-writer to the
+            // same key (single-writer-per-catalog is the documented
+            // contract).
+            let base = writer_id * 10_000;
+            for round in 0..ROUNDS {
+                for k in 0..KEYS_PER_WRITER {
+                    let id = base + k;
+                    db.put(make_row(id, round, &format!("w{writer_id}_r{round}")))
+                        .await
+                        .unwrap();
+                }
+            }
+        }));
+    }
+
+    // Concurrent flush + compact + scan. Bounded loops — 5 iterations
+    // of each, so the test runs deterministically.
+    let chaos_db = db.clone();
+    let chaos = tokio::spawn(async move {
+        for _ in 0..5 {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let _ = chaos_db.flush().await;
+            let _ = chaos_db.compact().await;
+            // Scan to assert it doesn't blow up under concurrent
+            // writers + flush + compact.
+            let _ = chaos_db.scan(None, None);
+        }
+    });
+
+    for h in writer_handles {
+        h.await.unwrap();
+    }
+    chaos.await.unwrap();
+
+    // Final flush so all writes are visible externally.
+    db.flush().await.unwrap();
+
+    // Oracle: every (writer, key) pair has its last round's value.
+    for w in 0..N_WRITERS {
+        let base = (w as i64) * 10_000;
+        for k in 0..KEYS_PER_WRITER {
+            let id = base + k;
+            let row = db
+                .get(&[FieldValue::Int64(id)])
+                .unwrap()
+                .unwrap_or_else(|| panic!("key {id} (w={w}) must exist"));
+            let version = row.get(1).unwrap();
+            assert_eq!(
+                *version,
+                FieldValue::Int64(ROUNDS - 1),
+                "key {id} must be at last round"
+            );
+        }
+    }
+
+    let total = (N_WRITERS as i64) * KEYS_PER_WRITER;
+    let scan = db.scan(None, None).unwrap();
+    assert_eq!(scan.len() as i64, total, "scan must return every key once");
+
+    Arc::try_unwrap(db).ok().unwrap().close().await.unwrap();
+}
+
+// ── Scenario 4: chaos: compaction race during flush DV resolve ───────────────
+
+/// Force a compaction to run between flushes that each emit DVs.
+/// The flush's resolve runs against the current pinned version; if
+/// compaction lands first, the L1+ files referenced by the resolve
+/// must still exist (compaction's GC honors the pin via
+/// `gc_grace_period_secs`). This test forces the race deterministically.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn chaos_compaction_during_flush_keeps_dv_consistent() {
+    let tmp = TempDir::new().unwrap();
+    let db = Arc::new(MeruDB::open(open(&tmp)).await.unwrap());
+
+    // Round 1: load 200 keys, flush, compact → goes to L1.
+    for id in 0..200 {
+        db.put(make_row(id, 0, "r0")).await.unwrap();
+    }
+    db.flush().await.unwrap();
+    db.compact().await.unwrap();
+
+    // Round 2: upsert all 200, flush → DV must mark all 200 in L1.
+    for id in 0..200 {
+        db.put(make_row(id, 1, "r1")).await.unwrap();
+    }
+    db.flush().await.unwrap();
+
+    // Round 3: trigger another compaction CONCURRENT with another
+    // upsert flush. The compaction may rewrite L1 (dropping DV-marked
+    // rows). The flush's resolve must hit the post-compaction version,
+    // not the pre-compaction one — commit_lock guarantees this.
+    let db_compact = db.clone();
+    let compact_task = tokio::spawn(async move {
+        let _ = db_compact.compact().await;
+    });
+    let db_flush = db.clone();
+    let flush_task = tokio::spawn(async move {
+        for id in 0..200 {
+            db_flush.put(make_row(id, 2, "r2")).await.unwrap();
+        }
+        db_flush.flush().await.unwrap();
+    });
+    flush_task.await.unwrap();
+    compact_task.await.unwrap();
+
+    // Final reads: every key at round 2.
+    for id in 0..200 {
+        let row = db.get(&[FieldValue::Int64(id)]).unwrap().unwrap();
+        let version = row.get(1).unwrap();
+        assert_eq!(*version, FieldValue::Int64(2), "key {id} must be at r2");
+    }
+    Arc::try_unwrap(db).ok().unwrap().close().await.unwrap();
+}
+
+// ── Scenario 5: large flush cardinality boundary ─────────────────────────────
+
+/// Flush with a memtable holding many keys all overlapping a single
+/// L1 file. Validates that the DV bitmap tracks every position
+/// without integer overflow / truncation. Memtable size capped to
+/// keep test runtime bounded; the cardinality is still in the
+/// thousands.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stress_large_dv_cardinality_per_file() {
+    let tmp = TempDir::new().unwrap();
+    // Larger memtable so more keys land in one L0 → one L1 file.
+    let opts = OpenOptions::new(schema())
+        .wal_dir(tmp.path().join("wal"))
+        .catalog_uri(tmp.path().to_string_lossy().to_string())
+        .memtable_size_mb(8)
+        .gc_grace_period_secs(0);
+    let db = MeruDB::open(opts).await.unwrap();
+
+    const N: i64 = 10_000;
+    for id in 0..N {
+        db.put(make_row(id, 0, "v0")).await.unwrap();
+    }
+    db.flush().await.unwrap();
+    db.compact().await.unwrap();
+
+    // Upsert every key.
+    for id in 0..N {
+        db.put(make_row(id, 1, "v1")).await.unwrap();
+    }
+    db.flush().await.unwrap();
+
+    // Total DV cardinality must be exactly N (every prior position
+    // marked once).
+    let card = total_dv_cardinality(&db).await;
+    assert_eq!(card, N as u64, "every prior position DV-marked");
+
+    // Reads return v1 for every key.
+    for id in (0..N).step_by(317) {
+        // Sample to keep test fast.
+        let row = db.get(&[FieldValue::Int64(id)]).unwrap().unwrap();
+        let version = row.get(1).unwrap();
+        assert_eq!(*version, FieldValue::Int64(1));
+    }
+
+    db.close().await.unwrap();
+}
+
+// ── Scenario 6: reopen recovers DV-bearing snapshot intact ───────────────────
+
+/// Crash-restart simulation (close + reopen) preserves DV state.
+/// After reopen the reads must agree with pre-close reads. RFC-0002:
+/// DV blobs are durable via the catalog's fsync-before-rename chain;
+/// reopening must surface them intact.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stress_reopen_preserves_dv_state() {
+    let tmp = TempDir::new().unwrap();
+    {
+        let db = MeruDB::open(open(&tmp)).await.unwrap();
+        for id in 0..100 {
+            db.put(make_row(id, 0, "v0")).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        db.compact().await.unwrap();
+        for id in 0..100 {
+            db.put(make_row(id, 1, "v1")).await.unwrap();
+        }
+        db.flush().await.unwrap();
+        let card_before = total_dv_cardinality(&db).await;
+        assert_eq!(card_before, 100);
+        db.close().await.unwrap();
+    }
+
+    // Reopen.
+    let db = MeruDB::open(open(&tmp)).await.unwrap();
+    let card_after = total_dv_cardinality(&db).await;
+    assert_eq!(card_after, 100, "DV state must survive reopen");
+
+    // Reads still return v1 for every key.
+    let mut by_id: HashMap<i64, i64> = HashMap::new();
+    for row in db.scan(None, None).unwrap() {
+        let id = row.1.get(0).cloned().unwrap();
+        let version = row.1.get(1).cloned().unwrap();
+        if let (FieldValue::Int64(i), FieldValue::Int64(v)) = (id, version) {
+            by_id.insert(i, v);
+        }
+    }
+    assert_eq!(by_id.len(), 100, "scan returns every key exactly once");
+    for v in by_id.values() {
+        assert_eq!(*v, 1, "every key at v1");
+    }
+
+    db.close().await.unwrap();
+}

--- a/docs/EXTERNAL_READS.md
+++ b/docs/EXTERNAL_READS.md
@@ -7,10 +7,34 @@ external reader MUST apply this projection.** A naive `SELECT *`
 returns MVCC duplicates and tombstones as if they were valid distinct
 rows — silent wrong answers.
 
-This contract is structurally unavoidable for any LSM-based external analytics
-table. It is not a temporary gap that future work removes. See
-[RFC #19](https://github.com/merutable/merutable/issues/19) for why
-Deletion Vectors cannot replace it.
+**As of 0.0.2 (RFC-0002, issue #73), snapshots produced by merutable's
+own flush emit per-file deletion vectors that DV-mark every prior
+version of every upserted/deleted memtable key. External Iceberg
+readers see one row per primary key without the projection below.**
+The projection is still required for:
+
+- Snapshots written by pre-0.0.2 merutable.
+- Snapshots written by a 0.0.2+ writer running with
+  `OpenOptions::enable_flush_dv_emission(false)`.
+- Tombstone filtering (`_merutable_op = 1`), which the projection
+  still handles since DVs cover prior versions but not the new
+  L0 row representing the delete.
+
+### How to tell which mode produced a snapshot
+
+Issue #93: every flush commit stamps a snapshot summary property
+`merutable.flush_dv_emission` set to `"true"` or `"false"`.
+Snapshots written before 0.0.2 do not carry the property at all.
+
+```sql
+-- DuckDB: list the snapshot summary properties.
+SELECT properties
+FROM iceberg_snapshots('/path/to/exported/metadata.json');
+```
+
+If the property is missing or `"false"`, apply the full projection
+below. If `"true"`, you can drop the `ROW_NUMBER()` deduplication
+and keep only the `_merutable_op = 1` tombstone filter.
 
 ## Go through the Iceberg manifest, never glob raw Parquet
 

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -5,41 +5,58 @@ This file exists to ground ambiguous README wording against the code
 that actually runs in production. When the README and this file
 disagree, this file wins and the README is wrong.
 
-## Deletion Vectors: honored on read, not emitted
+## Deletion Vectors: emitted at flush, honored on read
 
-merutable's own deletes are tombstone rows written through the normal
-LSM write path (`db.delete(pk)` → `write_internal(.., OpType::Delete)`);
-compaction reconciles them. No part of merutable's commit pipeline
-produces a Puffin `deletion-vector-v1` blob.
+As of 0.0.2 (RFC-0002, issue #73), every flush emits per-file
+deletion vectors that DV-mark every prior version of every
+upserted/deleted memtable key, across L0 + L1+ alike. The flush
+job, the manifest commit, and the puffin file write are one
+atomic unit (same `commit_lock`-serialized chain that compaction
+already used for partial-compaction DVs).
 
-What merutable *does* do is honor DVs if it encounters them. On every
-compaction merge and every read path, each input file is opened with
-its associated DV (if the manifest entry has a `dv_path`) and the
-marked row positions are filtered out before the merge iterator sees
-them. Implementation:
-`crates/merutable/src/engine/compaction/job.rs:open_source_file`,
-`crates/merutable/src/engine/read_path.rs`.
+This is the contract that gives external Iceberg readers
+(DuckDB `iceberg_scan`, Spark, Trino, pyiceberg) **one row per
+primary key without an MVCC dedup projection**. Removing the
+flush-side emission would re-introduce the duplicate-rows-per-PK
+leak `docs/EXTERNAL_READS.md` describes for pre-0.0.2 snapshots.
 
-This matters for Apache Iceberg v3 interop. An external writer
-(Spark, pyiceberg, Trino) can stamp a DV on a merutable-owned data
-file, and merutable will honor it on the next merge that touches the
-file. Removing the read-side would break v3 compatibility.
+Implementation:
+- Read path opens each file alongside its DV
+  (`crates/merutable/src/engine/read_path.rs`).
+- Compaction honors input DVs and rewrites without DV-marked rows
+  (`crates/merutable/src/engine/compaction/job.rs:open_source_file`).
+- Flush computes per-file DV deltas via range merge-intersection
+  (`crates/merutable/src/engine/dv_resolve.rs`), runs under
+  `commit_lock` against a pinned version snapshot, and stamps the
+  Puffin blobs into the same manifest commit as the new L0 SST
+  (`crates/merutable/src/engine/flush.rs`).
 
-The Puffin v3 `deletion-vector-v1` encoder in
-`crates/merutable/src/iceberg/deletion_vector.rs` and the
-`SnapshotTransaction::add_dv` API exist so that external tooling or
-future library-level commit flows can construct DV-stamped commits
-against a merutable catalog. The engine itself does not call them.
+`db.delete(pk)` still writes a logical tombstone row through the
+normal LSM write path (`OpType::Delete`); the flush emits the DV
+for the prior version's position, **and** keeps the L0 tombstone
+row so snapshot-pinned older readers and future compactions both
+see consistent state.
+
+External writers (Spark, pyiceberg, Trino) can also stamp v3 DVs on
+merutable-owned data files; merutable honors them uniformly on the
+read path and the next compaction.
+
+`OpenOptions::enable_flush_dv_emission(false)` opts out for
+workloads with no upserts where the resolve+emit cost is pure
+overhead. Default ON.
 
 ## MVCC semantics seen by external readers
 
-Short version: an external reader sees the *union* of every live
-Parquet file — which includes cross-level duplicates and tombstones.
-An `ORDER BY seq DESC, LIMIT 1` (or `ROW_NUMBER() QUALIFY …`)
-projection is required to recover the `MeruDB::get`/`scan`-equivalent
-view. Full treatment is in [docs/EXTERNAL_READS.md](EXTERNAL_READS.md) once
-that file lands; until then see the `IcebergCatalog::commit` and
-`read_path` modules.
+Post-0.0.2 the dedup projection is **no longer required** for
+snapshots produced by merutable's own flushes — flush-emitted DVs
+guarantee one row per PK per snapshot. The projection's only
+remaining role is back-compat with snapshots written by
+pre-0.0.2 merutable (or by callers running with
+`enable_flush_dv_emission(false)`). See
+[docs/EXTERNAL_READS.md](EXTERNAL_READS.md) for the legacy
+projection; new external integrations against 0.0.2+ snapshots
+should read the data files directly with each file's DV applied
+and skip the projection.
 
 ## Full-rewrite invariants
 

--- a/docs/rfc/0002-flush-time-deletion-vectors.md
+++ b/docs/rfc/0002-flush-time-deletion-vectors.md
@@ -309,14 +309,28 @@ Each phase is independently reviewable and lands as its own PR.
 - Resolve every memtable entry; aggregate by file; `txn.add_dv`.
 - Integration tests from the table above.
 
-**Phase 4 — bench harness**
+**Phase 4 — bench harness** (landed)
 
-- Criterion bench:
-  - `bench_put_latency` — p99 baseline + post.
-  - `bench_flush_with_dv` — flush wall time vs. memtable size, dv ON vs. OFF.
-  - `bench_range_scan_post_flush` — vs. clean-Parquet baseline.
-- Numbers committed to `docs/rfc/0002-flush-time-deletion-vectors.md`
-  as a "Measured" addendum.
+- Criterion bench at `crates/merutable/benches/flush_dv_emission.rs`:
+  - `put_latency/{dv_off, dv_on}` — single-row `put` latency on a
+    pre-populated DB (1K rows in L1 so the resolver has work on the
+    next flush); memtable size 64 MiB so puts never trigger a flush
+    mid-bench.
+  - `flush_overhead/{dv_off, dv_on}` — flush wall time of 1K upserts
+    against an L1 file holding 1K priors.
+- Range-scan-throughput bench is a follow-on (deferred to a separate
+  bench module that owns the clean-Parquet baseline construction).
+
+### Measured (macOS, criterion --quick)
+
+| Metric | DV off | DV on | Δ |
+|---|---|---|---|
+| `put` mean | 3.88 ms | 3.68 ms | within noise (dv-on slightly faster; dominated by per-put fsync) |
+| 1K-upsert flush | 26.9 ms | 31.8 ms | +4.9 ms (+18%) |
+
+**The load-bearing contract holds:** dv_on ≈ dv_off on `put`. The
++18% on flush is the amortized resolve+puffin-write cost paid at the
+flush boundary, not at the upsert. Per-row marginal: ~5 μs.
 
 **Phase 5 — docs**
 

--- a/docs/rfc/0002-flush-time-deletion-vectors.md
+++ b/docs/rfc/0002-flush-time-deletion-vectors.md
@@ -318,19 +318,27 @@ Each phase is independently reviewable and lands as its own PR.
     mid-bench.
   - `flush_overhead/{dv_off, dv_on}` — flush wall time of 1K upserts
     against an L1 file holding 1K priors.
-- Range-scan-throughput bench is a follow-on (deferred to a separate
-  bench module that owns the clean-Parquet baseline construction).
+- Range-scan-throughput bench landed in issue #91; numbers below.
 
 ### Measured (macOS, criterion --quick)
 
-| Metric | DV off | DV on | Δ |
+| Metric | Value | Comparator | Δ |
 |---|---|---|---|
-| `put` mean | 3.88 ms | 3.68 ms | within noise (dv-on slightly faster; dominated by per-put fsync) |
-| 1K-upsert flush | 26.9 ms | 31.8 ms | +4.9 ms (+18%) |
+| `put` mean (dv_off) | 3.88 ms | — | — |
+| `put` mean (dv_on) | 3.68 ms | dv_off | within noise |
+| 1K-upsert flush (dv_off) | 26.9 ms | — | — |
+| 1K-upsert flush (dv_on) | 31.8 ms | dv_off | +4.9 ms (+18%) |
+| 5K range-scan (clean) | 4.27 ms / 1.17 M elem/s | — | — |
+| 5K range-scan (post-upsert) | 6.75 ms / 0.74 M elem/s | clean | **0.63× throughput (1.58× slower)** — within the 2× bound |
 
 **The load-bearing contract holds:** dv_on ≈ dv_off on `put`. The
 +18% on flush is the amortized resolve+puffin-write cost paid at the
 flush boundary, not at the upsert. Per-row marginal: ~5 μs.
+
+**Range-scan post-flush stays within constant factor of clean.** The
+1.58× slowdown is the cost of opening DV blobs alongside data files
+and applying the bitmap during the merge — bounded, predictable,
+inside the 2× bar.
 
 **Phase 5 — docs**
 


### PR DESCRIPTION
Stacked on #97. Adds bench_window_scan to flush_dv_emission.rs.

Measured (5K rows, macOS):
- in_window:  14.34 ms / 348 K elem/s
- post_flush:  7.59 ms / 658 K elem/s
- ratio: 1.89x slower

Gap is real but within the 2x bar. Issue #92 stays OPEN — transient bitmask would close the gap but adds design complexity that should only be paid when a workload demands it. The bench is the gate: when ratio crosses 2x, take the issue back up.